### PR TITLE
Sequence Parallel system setup

### DIFF
--- a/playground/sp_rope.py
+++ b/playground/sp_rope.py
@@ -22,16 +22,19 @@ def gen_rope_model(config):
     num_head = getattr(config, "num_attention_heads")
     head_dim = hidden_size // num_head
 
-    print(head_dim, max_position_embeddings, rope_theta, rope_scaling, rope_is_neox_style)
+    print(
+        head_dim, max_position_embeddings, rope_theta, rope_scaling, rope_is_neox_style
+    )
     rope = get_rope(
-        head_dim,                               # 128
-        rotary_dim=head_dim,                    # 128
-        max_position=max_position_embeddings,   # 8192
-        base=rope_theta,                        # 5e5
-        rope_scaling=rope_scaling,              # None
-        is_neox_style=rope_is_neox_style,       # True
+        head_dim,  # 128
+        rotary_dim=head_dim,  # 128
+        max_position=max_position_embeddings,  # 8192
+        base=rope_theta,  # 5e5
+        rope_scaling=rope_scaling,  # None
+        is_neox_style=rope_is_neox_style,  # True
     )
     return rope
+
 
 def get_metadata(config):
     hidden_size = config.hidden_size
@@ -39,6 +42,7 @@ def get_metadata(config):
     num_kv_head = 8
     head_dim = hidden_size // num_head
     return num_head, num_kv_head, head_dim
+
 
 def gen_data(config, tp_size, sp_size, num_tokens):
     num_head, num_kv_head, head_dim = get_metadata(config)
@@ -56,7 +60,7 @@ def gen_data(config, tp_size, sp_size, num_tokens):
         length = random.randint(sp_size, num_tokens // 2)
         length = min(length, num_tokens - len(full_pos))
         len_offset = random.randint(0, num_tokens)
-        
+
         extend_seq_lens.append(length)
         extend_start_loc.append(len(full_pos))
 
@@ -64,19 +68,30 @@ def gen_data(config, tp_size, sp_size, num_tokens):
         # req_offset.append(len_offset)
     print(f"extend_seq_lens:{extend_seq_lens}")
     full_pos = torch.from_numpy(np.fromiter(full_pos, dtype=np.int32)).to(torch.long)
-    extend_seq_lens = torch.from_numpy(np.fromiter(extend_seq_lens, dtype=np.int32)).to(torch.long)
-    extend_start_loc = torch.from_numpy(np.fromiter(extend_start_loc, dtype=np.int32)).to(torch.long)
+    extend_seq_lens = torch.from_numpy(np.fromiter(extend_seq_lens, dtype=np.int32)).to(
+        torch.long
+    )
+    extend_start_loc = torch.from_numpy(
+        np.fromiter(extend_start_loc, dtype=np.int32)
+    ).to(torch.long)
     return full_q, full_k, full_pos, extend_seq_lens, extend_start_loc
 
-def gen_sp_indices(sp_size, extend_seq_lens, extend_start_loc, num_tokens, test: bool=False):
+
+def gen_sp_indices(
+    sp_size, extend_seq_lens, extend_start_loc, num_tokens, test: bool = False
+):
     all_indices = set()
     indices = []
     for sp_rank in range(sp_size):
-        sp_indices = get_prefill_indices(sp_rank, sp_size, extend_seq_lens, extend_start_loc)
+        sp_indices = get_prefill_indices(
+            sp_rank, sp_size, extend_seq_lens, extend_start_loc
+        )
         indices.append(sp_indices)
         if test:
             num_sp_indices = set([i for i in sp_indices])
-            assert all_indices.isdisjoint(set(num_sp_indices)), all_indices.intersection(num_sp_indices)
+            assert all_indices.isdisjoint(
+                set(num_sp_indices)
+            ), all_indices.intersection(num_sp_indices)
             all_indices.update(set(num_sp_indices))
     if test:
         assert all_indices == set(range(0, num_tokens))
@@ -85,17 +100,25 @@ def gen_sp_indices(sp_size, extend_seq_lens, extend_start_loc, num_tokens, test:
 
 ######## Function to be test
 def get_prefill_indices(sp_rank, sp_size, extend_seq_lens, extend_start_loc):
-    sp_req_len = extend_seq_lens // sp_size + ((extend_seq_lens % sp_size) > sp_rank).to(torch.long)
+    sp_req_len = extend_seq_lens // sp_size + (
+        (extend_seq_lens % sp_size) > sp_rank
+    ).to(torch.long)
     # the offset of each request in the batch. Only the first few ranks may get 1 more token (for each).
     # for sp_rank=r, there are r ranks ahread (since 0-based), each may get one token
-    sp_in_req_offset = extend_seq_lens // sp_size * sp_rank + torch.clamp(extend_seq_lens % sp_size, max=sp_rank)
+    sp_in_req_offset = extend_seq_lens // sp_size * sp_rank + torch.clamp(
+        extend_seq_lens % sp_size, max=sp_rank
+    )
     sp_req_start = extend_start_loc + sp_in_req_offset
-    sp_indices = torch.concat([torch.arange(s, s + l) for s, l in zip(sp_req_start, sp_req_len)])
+    sp_indices = torch.concat(
+        [torch.arange(s, s + l) for s, l in zip(sp_req_start, sp_req_len)]
+    )
     return sp_indices.cpu().numpy()
+
 
 def get_decode_mask(sp_rank, sp_size, seq_lens):
     # True means the corresponding token is located on this device. Otherwise False.
-    return (seq_lens % sp_size == sp_rank)
+    return seq_lens % sp_size == sp_rank
+
 
 @torch.no_grad()
 def main():
@@ -103,25 +126,27 @@ def main():
     tp_size = 4
     sp_size = 4
     num_tokens = 1280
-    (full_q, full_k, full_pos, extend_seq_lens,
-     extend_start_loc) = gen_data(config, tp_size, sp_size, num_tokens)
-    sp_indices = gen_sp_indices(sp_size, extend_seq_lens, extend_start_loc,
-                                num_tokens, test=True)
+    (full_q, full_k, full_pos, extend_seq_lens, extend_start_loc) = gen_data(
+        config, tp_size, sp_size, num_tokens
+    )
+    sp_indices = gen_sp_indices(
+        sp_size, extend_seq_lens, extend_start_loc, num_tokens, test=True
+    )
     # correct result
     rope = gen_rope_model(config)
     full_pos = full_pos.cuda()
     full_q = full_q.cuda().reshape(num_tokens, -1)
     full_k = full_k.cuda().reshape(num_tokens, -1)
 
-    cor_q, cor_k = rope(full_pos, torch.clone(full_q),
-                        torch.clone(full_k))
+    cor_q, cor_k = rope(full_pos, torch.clone(full_q), torch.clone(full_k))
 
     # simulated result
     test_q = torch.zeros_like(cor_q).squeeze(0)
     test_k = torch.zeros_like(cor_k).squeeze(0)
     for sp_idx in sp_indices:
-        q, k = rope(full_pos[sp_idx], torch.clone(full_q[sp_idx]),
-                    torch.clone(full_k[sp_idx]))
+        q, k = rope(
+            full_pos[sp_idx], torch.clone(full_q[sp_idx]), torch.clone(full_k[sp_idx])
+        )
         test_q[sp_idx] = q
         test_k[sp_idx] = k
     test_q = test_q.reshape(cor_q.shape)

--- a/playground/sp_rope.py
+++ b/playground/sp_rope.py
@@ -1,0 +1,133 @@
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+from transformers import AutoConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+
+
+def gen_rope_model(config):
+    hidden_size = config.hidden_size
+    rope_theta = getattr(config, "rope_theta", 10000)
+    rope_scaling = getattr(config, "rope_scaling", None)
+    if rope_scaling is not None and getattr(
+        config, "original_max_position_embeddings", None
+    ):
+        rope_scaling["original_max_position_embeddings"] = (
+            config.original_max_position_embeddings
+        )
+    rope_is_neox_style = getattr(config, "rope_is_neox_style", True)
+    max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+    num_head = getattr(config, "num_attention_heads")
+    head_dim = hidden_size // num_head
+
+    print(head_dim, max_position_embeddings, rope_theta, rope_scaling, rope_is_neox_style)
+    rope = get_rope(
+        head_dim,                               # 128
+        rotary_dim=head_dim,                    # 128
+        max_position=max_position_embeddings,   # 8192
+        base=rope_theta,                        # 5e5
+        rope_scaling=rope_scaling,              # None
+        is_neox_style=rope_is_neox_style,       # True
+    )
+    return rope
+
+def get_metadata(config):
+    hidden_size = config.hidden_size
+    num_head = getattr(config, "num_attention_heads")
+    num_kv_head = 8
+    head_dim = hidden_size // num_head
+    return num_head, num_kv_head, head_dim
+
+def gen_data(config, tp_size, sp_size, num_tokens):
+    num_head, num_kv_head, head_dim = get_metadata(config)
+    num_head_tp = num_head // tp_size
+    num_kv_head_tp = num_kv_head // tp_size
+    torch.manual_seed(42)
+    random.seed(42)
+    full_q = torch.rand((num_tokens, num_head_tp, head_dim), dtype=torch.bfloat16)
+    full_k = torch.rand((num_tokens, num_kv_head_tp, head_dim), dtype=torch.bfloat16)
+    full_pos = []
+    extend_seq_lens = []
+    extend_start_loc = []
+    # req_offset = []
+    while len(full_pos) < num_tokens:
+        length = random.randint(sp_size, num_tokens // 4)
+        length = min(length, num_tokens - len(full_pos))
+        len_offset = random.randint(0, num_tokens)
+        
+        extend_seq_lens.append(length)
+        extend_start_loc.append(len(full_pos))
+
+        full_pos.extend(range(len_offset, length + len_offset))
+        # req_offset.append(len_offset)
+    print(f"extend_seq_lens:{extend_seq_lens}")
+    full_pos = torch.from_numpy(np.fromiter(full_pos, dtype=np.int32)).to(torch.long)
+    extend_seq_lens = torch.from_numpy(np.fromiter(extend_seq_lens, dtype=np.int32)).to(torch.long)
+    extend_start_loc = torch.from_numpy(np.fromiter(extend_start_loc, dtype=np.int32)).to(torch.long)
+    return full_q, full_k, full_pos, extend_seq_lens, extend_start_loc
+
+def gen_sp_indices(sp_size, extend_seq_lens, extend_start_loc, num_tokens, test: bool=False):
+    all_indices = set()
+    indices = []
+    for sp_rank in range(sp_size):
+        sp_indices = get_prefill_indices(sp_rank, sp_size, extend_seq_lens, extend_start_loc)
+        indices.append(sp_indices)
+        if test:
+            num_sp_indices = set([i for i in sp_indices])
+            assert all_indices.isdisjoint(set(num_sp_indices)), all_indices.intersection(num_sp_indices)
+            all_indices.update(set(num_sp_indices))
+    if test:
+        assert all_indices == set(range(0, num_tokens))
+    return indices
+
+
+######## Function to be test
+def get_prefill_indices(sp_rank, sp_size, extend_seq_lens, extend_start_loc):
+    sp_req_len = extend_seq_lens // sp_size + ((extend_seq_lens % sp_size) > sp_rank).to(torch.long)
+    # the offset of each request in the batch. Only the first few ranks may get 1 more token (for each).
+    # for sp_rank=r, there are r ranks ahread (since 0-based), each may get one token
+    sp_in_req_offset = extend_seq_lens // sp_size * sp_rank + torch.clamp(extend_seq_lens % sp_size, max=sp_rank)
+    sp_req_start = extend_start_loc + sp_in_req_offset
+    sp_indices = torch.concat([torch.arange(s, s + l) for s, l in zip(sp_req_start, sp_req_len)])
+    return sp_indices.cpu().numpy()
+
+def sp_rope_forward(self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        offsets: Optional[torch.Tensor] = None,):
+    pass
+
+@torch.no_grad()
+def main():
+    config = AutoConfig.from_pretrained("meta-llama/Meta-Llama-3-8B-Instruct")
+    tp_size = 4
+    sp_size = 4
+    num_tokens = 32
+    full_q, full_k, full_pos, extend_seq_lens, extend_start_loc = gen_data(config, tp_size, sp_size, num_tokens)
+    sp_indices = gen_sp_indices(sp_size, extend_seq_lens, extend_start_loc, num_tokens, test=True)
+    # correct result
+    rope = gen_rope_model(config)
+    full_pos = full_pos.cuda()
+    full_q = full_q.cuda().reshape(num_tokens, -1)
+    full_k = full_k.cuda().reshape(num_tokens, -1)
+
+    cor_q, cor_k = rope(full_pos, full_q, full_k)
+
+    # simulated result
+    test_q = torch.zeros_like(cor_q)
+    test_k = torch.zeros_like(cor_k)
+    for sp_idx in sp_indices:
+        q, k = rope.forward_native(full_pos[sp_idx], full_q[sp_idx], full_k[sp_idx])
+        torch.testing.assert_close(full_q[sp_idx], q.squeeze(0))
+        exit(-1)
+        test_q[sp_idx] = q
+        test_k[sp_idx] = k
+
+    torch.testing.assert_close(full_q, test_q)
+    torch.testing.assert_close(full_k, test_k)
+
+
+main()

--- a/playground/sp_rope.py
+++ b/playground/sp_rope.py
@@ -93,6 +93,10 @@ def get_prefill_indices(sp_rank, sp_size, extend_seq_lens, extend_start_loc):
     sp_indices = torch.concat([torch.arange(s, s + l) for s, l in zip(sp_req_start, sp_req_len)])
     return sp_indices.cpu().numpy()
 
+def get_decode_mask(sp_rank, sp_size, seq_lens):
+    # True means the corresponding token is located on this device. Otherwise False.
+    return (seq_lens % sp_size == sp_rank)
+
 @torch.no_grad()
 def main():
     config = AutoConfig.from_pretrained("meta-llama/Meta-Llama-3-8B-Instruct")

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -68,7 +68,7 @@ class BenchArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
 
-def load_model(server_args, tp_rank, sp_rank: int=0):
+def load_model(server_args, tp_rank, sp_rank: int = 0):
     suppress_other_loggers()
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -181,7 +181,7 @@ def correctness_test(
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 
     # Load the model
-    model_runner, tokenizer = load_model(server_args, tp_rank)
+    model_runner, tokenizer = load_model(server_args, tp_rank, sp_rank)
 
     # Prepare inputs
     input_ids, reqs = prepare_inputs(bench_args, tokenizer)

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -176,6 +176,7 @@ def correctness_test(
     server_args,
     bench_args,
     tp_rank,
+    sp_rank=0,
 ):
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -631,8 +631,8 @@ class Batch:
             self.tree_cache.pretty_print()
             exit()
 
-        if self.sp_size > 1:
-            return  # FIXME(yonghao): remove it once SP kv cache store is ready
+        if self.sp_size > 1 and False:
+            # FIXME(yonghao): enable remove it once SP kv cache store is ready
             local_req_indices = self.req_pool_indices[sp_local_indices]
             # NOTE(yonghao): here the seqlen is still the total seq len but not
             # the local lens

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -369,7 +369,7 @@ class Batch:
         for flatten_ids in flatten_input_ids:
             if len(flatten_ids) < padded_sp_len:
                 flatten_ids.extend([0] * (padded_sp_len - len(flatten_ids)))
-        flatten_input_ids = list(itertools.chain(flatten_input_ids))
+        flatten_input_ids = list(itertools.chain(*flatten_input_ids))
         self.padded_sp_len = padded_sp_len
 
         position_ids_offsets = torch.zeros((bs,), dtype=torch.int32, device=device)
@@ -599,7 +599,7 @@ class Batch:
             ]
         self.seq_lens.add_(1)
         input_ids_sp = [[] for _ in range(self.sp_size)]
-        prefix_lens = self.prefix_lens if self.prefix_lens is not None else 0
+        prefix_lens = self.prefix_lens or 0
         seq_lens_cpu = (self.seq_lens - prefix_lens).cpu().numpy()
         for sp_rank in range(self.sp_size):
             # TODO(yonghao): double check moving the seq lens adds one to above.
@@ -611,8 +611,8 @@ class Batch:
             if len(flatten_ids) < padded_sp_len:
                 flatten_ids.extend([0] * (padded_sp_len - len(flatten_ids)))
         self.padded_sp_len = padded_sp_len
-        
-        input_ids = list(itertools.chain(input_ids_sp))
+
+        input_ids = list(itertools.chain(*input_ids_sp))
         self.input_ids = torch.tensor(input_ids, dtype=torch.int32, device="cuda")
         self.prefix_lens = None
 
@@ -862,6 +862,7 @@ class InputMetadata:
         sp_rank = model_runner.sp_rank
         sp_size = model_runner.sp_size
         if sp_size > 1:
+            # FIXME: haven't supported cuda graph yet.
             # During the runtime, we should use positions[local_token_indices]
             # to get positions for each SP shard.
             prefix_lens = prefix_lens if prefix_lens is not None else 0
@@ -1094,13 +1095,13 @@ def _debug_normal_to_sp_indices(mode, sp_size, seq_lens, sp_padded_len):
     """(Debug only) Indices from normal layout to the SP layout (padded)."""
     get_indices_fn = (get_decode_indices
                       if mode == ForwardMode.DECODE else get_prefill_indices)
-    def get_offset(sp_rank):
-        offset = sp_rank * sp_padded_len
-        if mode == ForwardMode.DECODE:
-            return offset
-        return [offset] * len(seq_lens)
+    offset = (0
+              if mode == ForwardMode.DECODE else
+              np.concatenate([np.asarray([0], dtype=np.int32),
+                              np.cumsum(seq_lens[:-1])])
+             )
     indices = [
-        get_indices_fn(sp_rank, sp_size, seq_lens, get_offset(sp_rank))
+        get_indices_fn(sp_rank, sp_size, seq_lens, offset)
         for sp_rank in range(sp_size)
     ]
     return indices

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -295,7 +295,8 @@ class Batch:
     local_token_offsets: List[int] = None
 
     @classmethod
-    def init_new(cls, reqs, req_to_token_pool, token_to_kv_pool, tree_cache):
+    def init_new(cls, reqs, req_to_token_pool, token_to_kv_pool, tree_cache,
+                 sp_size: int = 1, sp_rank: int = 0):
         return_logprob = any(req.return_logprob for req in reqs)
 
         return cls(
@@ -304,6 +305,8 @@ class Batch:
             token_to_kv_pool=token_to_kv_pool,
             tree_cache=tree_cache,
             return_logprob=return_logprob,
+            sp_size=sp_size,
+            sp_rank=sp_rank,
         )
 
     def is_empty(self):

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -351,9 +351,8 @@ class Batch:
             for sp_rank in range(self.sp_size):
                 ids = input_ids[i]
                 local_slice = _get_local_token_slices(sp_rank, self.sp_size,
-                                                      len(ids[i]))
+                                                      len(ids))
                 flatten_input_ids[sp_rank].extend(ids[local_slice])
-            flatten_input_ids.extend(input_ids[i])
             extend_lens.append(len(input_ids[i]))
 
             if len(prefix_indices[i]) == 0:
@@ -371,7 +370,7 @@ class Batch:
         for flatten_ids in flatten_input_ids:
             if len(flatten_ids) < local_len_padded:
                 flatten_ids.extend([0] * (local_len_padded - len(flatten_ids)))
-        flatten_input_ids = itertools.chain(flatten_input_ids)
+        flatten_input_ids = list(itertools.chain(flatten_input_ids))
 
         position_ids_offsets = torch.zeros((bs,), dtype=torch.int32, device=device)
 
@@ -769,8 +768,8 @@ class InputMetadata:
     flashinfer_decode_wrapper: "BatchDecodeWithPagedKVCacheWrapper" = None
 
     # For Sequence Parallel
-    seq_parallel_rank: int = None
-    seq_parallel_size: int = None
+    sp_rank: int = None
+    sp_size: int = None
 
     @classmethod
     def create(
@@ -850,8 +849,8 @@ class InputMetadata:
             flashinfer_prefill_wrapper_ragged=model_runner.flashinfer_prefill_wrapper_ragged,
             flashinfer_prefill_wrapper_paged=model_runner.flashinfer_prefill_wrapper_paged,
             flashinfer_decode_wrapper=model_runner.flashinfer_decode_wrapper,
-            seq_parallel_rank=model_runner.seq_parallel_rank,
-            seq_parallel_size=model_runner.seq_parallel_size,
+            sp_rank=model_runner.sp_rank,
+            sp_size=model_runner.sp_size,
         )
 
         if model_runner.server_args.disable_flashinfer:

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -405,7 +405,7 @@ class Batch:
             self.req_to_token_pool.req_to_token[req_pool_indices_cpu[i]][
                 prefix_lens[i] : prefix_lens[i] + extend_len
             ] = out_cache_loc[pt : pt + extend_len]
-            pt += extend_lens[i]
+            pt += extend_len
 
         # Handle logit bias but only allocate when needed
         logit_bias = None

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -258,6 +258,7 @@ class ModelRunner:
             out_cache_loc=batch.out_cache_loc,
             top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
+            padded_sp_len=batch.padded_sp_len,
         )
         return self.model.forward(
             batch.input_ids, input_metadata.positions, input_metadata
@@ -275,6 +276,7 @@ class ModelRunner:
             out_cache_loc=batch.out_cache_loc,
             top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
+            padded_sp_len=batch.padded_sp_len,
         )
         return self.model.forward(
             batch.input_ids, input_metadata.positions, input_metadata

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -49,8 +49,8 @@ class ModelRunner:
         tp_size: int,
         nccl_port: int,
         server_args: ServerArgs,
-        sp_rank: Optional[int] = None,
-        sp_size: Optional[int] = None,
+        sp_rank: int = 0,
+        sp_size: int = 1,
     ):
         # Parse args
         self.model_config = model_config

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -49,6 +49,8 @@ class ModelRunner:
         tp_size: int,
         nccl_port: int,
         server_args: ServerArgs,
+        sp_rank: Optional[int] = None,
+        sp_size: Optional[int] = None,
     ):
         # Parse args
         self.model_config = model_config
@@ -56,6 +58,8 @@ class ModelRunner:
         self.gpu_id = gpu_id
         self.tp_rank = tp_rank
         self.tp_size = tp_size
+        self.sp_rank = sp_rank
+        self.sp_size = sp_size
         self.nccl_port = nccl_port
         self.server_args = server_args
         self.is_multimodal_model = is_multimodal_model(self.model_config)

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -141,11 +141,24 @@ class LlamaAttention(nn.Module):
         hidden_states: torch.Tensor,
         input_metadata: InputMetadata,
     ) -> torch.Tensor:
+        if input_metadata.sp_size > 1:
+            ori_hidden_states = hidden_states
+            hidden_states = hidden_states[
+                input_metadata.sp_to_normal_indices
+            ].contiguous()
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, input_metadata)
         output, _ = self.o_proj(attn_output)
+        if input_metadata.sp_size > 1:
+            output_sp = torch.zeros_like(ori_hidden_states).reshape(
+                input_metadata.sp_size, -1, *ori_hidden_states.shape[1:]
+            )
+            for sp_rank, idxs in enumerate(input_metadata._debug_normal_to_sp_metadata):
+                sp_real_vals = output[idxs]
+                output_sp[sp_rank][:sp_real_vals.shape[0]] = sp_real_vals
+            output = output_sp.reshape(ori_hidden_states.shape).contiguous()
         return output
 
 
@@ -284,6 +297,13 @@ class LlamaForCausalLM(nn.Module):
         input_embeds: torch.Tensor = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, input_metadata, input_embeds)
+        if input_metadata.sp_size > 1:
+            hidden_states = hidden_states[
+                input_metadata.sp_to_normal_indices
+            ].contiguous()
+            input_ids = input_ids[
+                input_metadata.sp_to_normal_indices
+            ].contiguous()
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head.weight, input_metadata
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -33,6 +33,7 @@ class ServerArgs:
 
     # Other runtime options
     tp_size: int = 1
+    sp_size: int = 1
     stream_interval: int = 8
     random_seed: Optional[int] = None
 
@@ -210,6 +211,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.tp_size,
             help="The tensor parallelism size.",
+        )
+        parser.add_argument(
+            "--sp-size",
+            type=int,
+            default=ServerArgs.sp_size,
+            help="The sequence parallelism size.",
         )
         parser.add_argument(
             "--stream-interval",


### PR DESCRIPTION
This PR:

- [x] Add `sp_size` and `sp_rank` in model runner args.
- [x] Get the local sequence indices of each request for the prefill stage. (seems no longer needed after the SP layout...)
- [x] When preparing `input_ids`, it reorders them by `[req_0_sp_0, req_1_sp_0, ..., req_n_sp_0, req_1_sp_1, ...]`. In this way, when switching to the sequence parallel, there only needs an `AllGather` but no re-indexing.
- [x] Generate the corresponding position ids.
- [x] Fix LogitProcessorOutput for the above SP layout (simply a walkaround now. should avoid tensor transpose later).
- [x] Since we don't have real SP attention kernel in this PR, we actually reorder back to the original layout before the attention kernel and shift it back. So the performance is not high. This is only for correctness check and should be removed later.
- [x] (not tested) KV cache are stored following the above SP layout.

Generally, we have 3 layouts for tokens:

1. Normal layout, which is `[req_1, req_2, ...]`
2. Sequence Parallel layout no padding, which is `[req_1_sp_0, req_2_sp_0, ... req_n_sp_0, req_1_sp_1, ...]`;
3. Sequence Parallel layout, padded. When `#tokens(req) % sp_size != 0`, the first few sequence parallel ranks will have more tokens. To make operations like AllGather easy, other sequence parallel ranks are padded. This one looks like:
```
[
  req_1_sp_0, req_2_sp_0, ... req_n_sp_0,
  req_1_sp_1, req_2_sp_1, ... req_n_sp_1, padding_sp_1,
  req_1_sp_2, req_2_sp_2, ... req_n_sp_2, padding_sp_2,
  ...
]
```
Here we write it as if it's a 2D matrix, but it's actually 1-D. For each SP rank, padding is only added at the end (instead of at every req's end).