### PR TITLE
Sequence parallel prefill attention kernel

### DIFF
--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -98,8 +98,8 @@ def load_model(server_args, tp_rank, sp_rank: int = 0):
 def prepare_inputs(bench_args, tokenizer):
     prompts = [
         "The capital of France is",
-        "The capital of the United Kindom is",
-        "Today is a sunny day and I like",
+        "The capital of the United Kindom",
+        "Today is a sunny day and I like to",
     ]
     input_ids = [tokenizer.encode(p) for p in prompts]
     sampling_params = SamplingParams(
@@ -199,16 +199,16 @@ def correctness_test(
     rank_print("prefill logits (final)", next_token_logits)
 
     # FIXME (yifan): enable decode later.
-    # # # Decode
-    # # output_ids = [input_ids[i] + [next_token_ids[i]] for i in range(len(input_ids))]
-    # # for _ in range(bench_args.output_len):
-    # #     next_token_ids, _ = decode(next_token_ids, batch, model_runner)
-    # #     for i in range(len(reqs)):
-    # #         output_ids[i].append(next_token_ids[i])
+    # Decode
+    output_ids = [input_ids[i] + [next_token_ids[i]] for i in range(len(input_ids))]
+    # for _ in range(bench_args.output_len):
+    #     next_token_ids, _ = decode(next_token_ids, batch, model_runner)
+    #     for i in range(len(reqs)):
+    #         output_ids[i].append(next_token_ids[i])
 
-    # # Print
-    # for i in range(len(reqs)):
-    #     rank_print(tokenizer.decode(output_ids[i]))
+    # Print
+    for i in range(len(reqs)):
+        rank_print(tokenizer.decode(output_ids[i]))
 
 
 def latency_test(

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -198,16 +198,17 @@ def correctness_test(
     next_token_ids, next_token_logits, batch = extend(reqs, model_runner)
     rank_print("prefill logits (final)", next_token_logits)
 
-    # Decode
-    output_ids = [input_ids[i] + [next_token_ids[i]] for i in range(len(input_ids))]
-    for _ in range(bench_args.output_len):
-        next_token_ids, _ = decode(next_token_ids, batch, model_runner)
-        for i in range(len(reqs)):
-            output_ids[i].append(next_token_ids[i])
+    # FIXME (yifan): enable decode later.
+    # # # Decode
+    # # output_ids = [input_ids[i] + [next_token_ids[i]] for i in range(len(input_ids))]
+    # # for _ in range(bench_args.output_len):
+    # #     next_token_ids, _ = decode(next_token_ids, batch, model_runner)
+    # #     for i in range(len(reqs)):
+    # #         output_ids[i].append(next_token_ids[i])
 
-    # Print
-    for i in range(len(reqs)):
-        rank_print(tokenizer.decode(output_ids[i]))
+    # # Print
+    # for i in range(len(reqs)):
+    #     rank_print(tokenizer.decode(output_ids[i]))
 
 
 def latency_test(

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -98,8 +98,8 @@ def load_model(server_args, tp_rank, sp_rank: int = 0):
 def prepare_inputs(bench_args, tokenizer):
     prompts = [
         "The capital of France is",
-        "The capital of the United Kindom",
-        "Today is a sunny day and I like to",
+        "The capital of the United Kindom is",
+        "Today is a sunny day and I like",
     ]
     input_ids = [tokenizer.encode(p) for p in prompts]
     sampling_params = SamplingParams(

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -181,7 +181,7 @@ def correctness_test(
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 
     # Load the model
-    model_runner, tokenizer = load_model(server_args, tp_rank)
+    model_runner, tokenizer = load_model(server_args, tp_rank, sp_rank)
 
     # Prepare inputs
     input_ids, reqs = prepare_inputs(bench_args, tokenizer)
@@ -219,7 +219,7 @@ def latency_test(
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 
     # Load the model
-    model_runner, tokenizer = load_model(server_args, tp_rank)
+    model_runner, tokenizer = load_model(server_args, tp_rank, sp_rank)
     rank_print(
         f"max_batch_size={model_runner.max_total_num_tokens // (bench_args.input_len + bench_args.output_len)}"
     )

--- a/python/sglang/bench_latency.py
+++ b/python/sglang/bench_latency.py
@@ -214,6 +214,7 @@ def latency_test(
     server_args,
     bench_args,
     tp_rank,
+    sp_rank=0,
 ):
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
 
@@ -290,7 +291,7 @@ def main(server_args, bench_args):
         work_func = latency_test
 
     if server_args.tp_size == 1:
-        work_func(server_args, bench_args, 0)
+        work_func(server_args, bench_args, 0, 0)
     else:
         workers = []
         for tp_rank in range(server_args.tp_size):

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -80,6 +80,9 @@ class QKVParallelLinear(torch.nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
     ):
         super().__init__()
+        # FIXME (yifan): output_size should be head_size * total_num_heads // sp_size.
+        # We probably need to manually partition the q_proj in this case since RowPrallelLinear
+        # will perform all-gather after the computation.
         # q projection can be naively tensor parallelized
         self.q_proj = RowParallelLinear(
             hidden_size,

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1,0 +1,300 @@
+import logging
+from typing import Dict, Optional, Tuple
+
+import torch
+from torch.nn.parameter import Parameter
+from vllm.distributed import divide, get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.linear import ColumnParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+from sglang.srt.layers.parallel_utils.parallel_state import (
+    get_actual_tensor_model_parallel_rank,
+    get_actual_tensor_model_parallel_world_size,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Adapted from
+# https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L21
+def adjust_marlin_shard(param, shard_size, shard_offset):
+    marlin_tile_size = getattr(param, "marlin_tile_size", None)
+    if marlin_tile_size is None:
+        return shard_size, shard_offset
+
+    return shard_size * marlin_tile_size, shard_offset * marlin_tile_size
+
+
+# Adapted from
+# https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L29
+def adjust_bitsandbytes_shard(
+    param: Parameter, kv_offsets: Dict[str, Tuple[int, int]], loaded_shard_id: str
+) -> Tuple[int, int]:
+    """Adjust the quantization offsets and sizes for BitsAndBytes sharding."""
+
+    total, _ = kv_offsets["total"]
+    orig_offset, orig_size = kv_offsets[loaded_shard_id]
+
+    quantized_total = param.data.shape[0]
+    quantized_offset = orig_offset * quantized_total // total
+    quantized_size = orig_size * quantized_total // total
+
+    return quantized_size, quantized_offset
+
+
+# Adapted from
+# https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L44
+def adjust_scalar_to_fused_array(param, loaded_weight, shard_id):
+    """For fused modules (KV) we have an array of length
+    N that holds 1 scale for each "logical" matrix. So the param
+    is an array of length N. The loaded_weight corresponds to
+    one of the shards on disk. Here, we slice the param based on
+    the shard_id for loading.
+    """
+    qkv_idxs = {"k": 0, "v": 1}
+
+    if isinstance(shard_id, str):
+        shard_id = qkv_idxs[shard_id]
+    elif not isinstance(shard_id, int):
+        raise ValueError(f"Unknown Shard Id {shard_id}")
+
+    # AutoFP8 scales do not have a shape
+    # compressed-tensors scales do have a shape
+    if len(loaded_weight.shape) != 0:
+        assert loaded_weight.shape[0] == 1
+        loaded_weight = loaded_weight[0]
+
+    return param[shard_id], loaded_weight
+
+
+class QKVParallelLinear(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: Optional[int] = None,
+        bias: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: Optional[torch.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+    ):
+        super().__init__()
+        # q projection can be naively tensor parallelized
+        self.q_proj = RowParallelLinear(
+            hidden_size,
+            head_size * total_num_heads,
+            bias,
+            skip_bias_add,
+            params_dtype,
+            quant_config,
+        )
+        # kv projection needs both tensor and sequence parallelization
+        self.kv_proj = KVSequenceParallelLinear(
+            hidden_size,
+            head_size,
+            total_num_heads,
+            total_num_kv_heads,
+            bias,
+            skip_bias_add,
+            params_dtype,
+            quant_config,
+        )
+        self.kv_size = self.kv_proj.num_kv_heads * self.kv_proj.head_size
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        q, _ = self.q_proj(hidden_states)
+        kv, _ = self.kv_proj(hidden_states)
+        k, v = kv.split([self.kv_size, self.kv_size], dim=-1)
+        return q, k, v
+
+
+# Adapted from
+# https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L422
+class KVSequenceParallelLinear(ColumnParallelLinear):
+    """Linear layers for the attention's KV transformation.
+
+    Linear layers for the linear transformation of the key, and value
+    vectors in the attention layer. The weight matrix is concatenated along
+    the output dimension. The layer is parallelized along the head dimension.
+    When the number of key/value heads is smaller than the number of query
+    heads (e.g., multi-query/grouped-query attention), the key/value head may
+    be replicated while the query heads are partitioned.
+
+    Args:
+        hidden_size: input hidden state size of the transformer.
+        head_size: size of each attention head.
+        total_num_heads: total number of attention query heads.
+        total_num_kv_heads: total number of attention key/value heads. If
+                            None, assume total_num_kv_heads = total_num_heads.
+        bias: If true, add bias.
+        skip_bias_add: This was added to enable performance optimizations where
+                       bias can be fused with other element-wise operations. we
+                       skip adding bias but instead return it.
+        params_dtype: Data type for the parameters.
+        linear_method: (Maybe quantized) linear method.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: Optional[int] = None,
+        bias: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: Optional[torch.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+    ):
+        self.hidden_size = hidden_size
+        self.head_size = head_size
+        if total_num_kv_heads is None:
+            total_num_kv_heads = total_num_heads
+        self.total_num_kv_heads = total_num_kv_heads
+        # Divide the weight matrix along the last dimension.
+        actual_tp_size = get_actual_tensor_model_parallel_world_size()
+        if actual_tp_size >= self.total_num_kv_heads:
+            self.num_kv_heads = 1
+            self.num_kv_head_replicas = divide(actual_tp_size, self.total_num_kv_heads)
+        else:
+            self.num_kv_heads = divide(self.total_num_kv_heads, actual_tp_size)
+            self.num_kv_head_replicas = 1
+        input_size = self.hidden_size
+        # NOTE (yifan): here we use tp_size to make parent class happy. This is
+        # because parent class expects pure tensor parallelism.
+        tp_size = get_tensor_model_parallel_world_size()
+        output_size = 2 * self.num_kv_heads * tp_size * self.head_size
+        self.output_sizes = [
+            self.num_kv_heads * self.head_size * tp_size,  # k_proj
+            self.num_kv_heads * self.head_size * tp_size,  # v_proj
+        ]
+
+        super().__init__(
+            input_size=input_size,
+            output_size=output_size,
+            bias=bias,
+            gather_output=False,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+        )
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: Optional[str] = None,
+    ):
+        param_data = param.data
+        output_dim = getattr(param, "output_dim", None)
+        # Special case for AQLM codebooks.
+        is_metadata = getattr(param, "is_metadata", False)
+
+        # Special case for per-tensor scales in fused case.
+        needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
+
+        if loaded_shard_id is None:
+            # Loaded weight is already fused on disk (qkv/mlp).
+            raise NotImplementedError("Fused weight loading is not supported.")
+            if output_dim is None:
+                assert param_data.shape == loaded_weight.shape
+                param_data.copy_(loaded_weight)
+                return
+            shard_offsets = [
+                # (shard_id, shard_offset, shard_size)
+                (
+                    "k",
+                    0,
+                    self.total_num_kv_heads * self.head_size,
+                ),
+                (
+                    "v",
+                    self.total_num_kv_heads * self.head_size,
+                    self.total_num_kv_heads * self.head_size,
+                ),
+            ]
+            packed_dim = getattr(param, "packed_dim", None)
+            for shard_id, shard_offset, shard_size in shard_offsets:
+                # If quantized, we need to adjust the offset and size to account
+                # for the packing.
+                if packed_dim == output_dim:
+                    shard_size = shard_size // param.pack_factor
+                    shard_offset = shard_offset // param.pack_factor
+                loaded_weight_shard = loaded_weight.narrow(
+                    output_dim, shard_offset, shard_size
+                )
+                self.weight_loader(param, loaded_weight_shard, shard_id)
+            return
+
+        actual_tp_rank = get_actual_tensor_model_parallel_rank()
+        assert loaded_shard_id in ["k", "v"]
+
+        # If output dim is defined, use the default loading process.
+        if output_dim is not None:
+            if loaded_shard_id == "k":
+                shard_offset = 0
+                shard_size = self.num_kv_heads * self.head_size
+            elif loaded_shard_id == "v":
+                shard_offset = self.num_kv_heads * self.head_size
+                shard_size = self.num_kv_heads * self.head_size
+            # Special case for Quantized Weights.
+            # If quantized, we need to adjust the offset and size to account
+            # for the packing.
+            packed_dim = getattr(param, "packed_dim", None)
+            if packed_dim == output_dim:
+                shard_size = shard_size // param.pack_factor
+                shard_offset = shard_offset // param.pack_factor
+
+                # Special case for Marlin.
+                shard_size, shard_offset = adjust_marlin_shard(
+                    param, shard_size, shard_offset
+                )
+
+            use_bitsandbytes = getattr(param, "use_bitsandbytes", False)
+            if use_bitsandbytes:
+                orig_kv_offsets = {
+                    "k": (
+                        0,
+                        self.num_kv_heads * self.head_size,
+                    ),
+                    "v": (
+                        self.num_kv_heads * self.head_size,
+                        self.num_kv_heads * self.head_size,
+                    ),
+                    "total": (
+                        2 * self.num_kv_heads * self.head_size,
+                        0,
+                    ),
+                }
+                shard_size, shard_offset = adjust_bitsandbytes_shard(
+                    param, orig_kv_offsets, loaded_shard_id
+                )
+
+            param_data = param_data.narrow(output_dim, shard_offset, shard_size)
+            shard_id = actual_tp_rank // self.num_kv_head_replicas
+            start_idx = shard_id * shard_size
+            loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        # Special case for for AQLM codebooks.
+        elif is_metadata:
+            # metadata indicates fixed size concatenated along dim 0
+            shard_size = loaded_weight.shape[0]
+            shard_index = ["k", "v"].index(loaded_shard_id)
+            param_data = param_data.narrow(0, shard_index * shard_size, shard_size)
+        # Special case for per-tensor scales in fused case.
+        elif needs_scalar_to_array:
+            param_data, loaded_weight = adjust_scalar_to_fused_array(
+                param_data, loaded_weight, loaded_shard_id
+            )
+        else:
+            ignore_warning = getattr(param, "ignore_warning", False)
+            if not ignore_warning:
+                logger.warning(
+                    "Loading a weight without `output_dim` attribute in "
+                    "QKVParallelLinear, assume the weight is the same "
+                    "for all partitions."
+                )
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -308,8 +308,8 @@ class KVSequenceParallelLinear(ColumnParallelLinear):
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L660
 class RowSeqParallelLinear(RowParallelLinear):
-    """ TODO: add doc string.
-    """
+    """TODO: add doc string."""
+
     def __init__(
         self,
         input_size: int,

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -88,7 +88,7 @@ class QKVParallelLinear(torch.nn.Module):
             quant_config,
         )
         # kv projection needs both tensor and sequence parallelization
-        self.kv_proj = KVSequenceParallelLinear(
+        self.kv_proj = KVSeqParallelLinear(
             hidden_size,
             head_size,
             total_num_heads,
@@ -198,8 +198,6 @@ class ColumnSeqParallelLinear(ColumnParallelLinear):
         # Special case for loading scales off disk, which often do not
         # have a shape (such as in the case of AutoFP8).
         if len(loaded_weight.shape) == 0:
-            if sp_size > 1:
-                raise NotImplementedError("Loading scales off disk is not supported.")
             loaded_weight = loaded_weight.reshape(1)
 
         assert param_data.shape == loaded_weight.shape
@@ -208,7 +206,7 @@ class ColumnSeqParallelLinear(ColumnParallelLinear):
 
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/layers/linear.py#L422
-class KVSequenceParallelLinear(ColumnParallelLinear):
+class KVSeqParallelLinear(ColumnParallelLinear):
     """Linear layers for the attention's KV transformation.
 
     Linear layers for the linear transformation of the key, and value
@@ -462,8 +460,6 @@ class RowSeqParallelLinear(RowParallelLinear):
         # Special case for loading scales off disk, which often do not
         # have a shape (such as in the case of AutoFP8).
         if len(loaded_weight.shape) == 0:
-            if sp_size > 1:
-                raise NotImplementedError("Loading scales off disk is not supported.")
             loaded_weight = loaded_weight.reshape(1)
 
         assert param_data.shape == loaded_weight.shape

--- a/python/sglang/srt/layers/parallel_utils/__init__.py
+++ b/python/sglang/srt/layers/parallel_utils/__init__.py
@@ -1,0 +1,1 @@
+from .parallel_state import *

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -79,9 +79,13 @@ def get_sequence_parallel_rank():
     return get_sp_group().rank_in_group
 
 
-def get_actual_tensor_model_parallel_world_size():
+# NOTE: For sequence parallelism, we partition Q tensors along the head dimension.
+# But K/V tensors are partitioned along the head dimension in TP and partitioned
+# along the sequence dimensions in SP. Therefore, their TP size and rank is adjusted
+# accordingly as below.
+def get_kv_tensor_model_parallel_world_size():
     return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
 
 
-def get_actual_tensor_model_parallel_rank():
+def get_kv_tensor_model_parallel_rank():
     return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -81,9 +81,9 @@ def get_sequence_parallel_prev_rank(rank: Optional[int] = None):
     return prev_rank
 
 
-def get_actual_tensor_model_parallel_world_size():
+def get_kv_tensor_model_parallel_world_size():
     return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
 
 
-def get_actual_tensor_model_parallel_rank():
+def get_kv_tensor_model_parallel_rank():
     return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -1,0 +1,79 @@
+from vllm.distributed import initialize_model_parallel as vllm_initialize_model_parallel
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_group,
+    get_tensor_model_parallel_rank,
+)
+
+_SEQUENCE_PARALLEL_SIZE = None
+
+
+def initialize_model_parallel(
+    tensor_model_parallel_size: int = 1,
+    pipeline_model_parallel_size: int = 1,
+    sequence_parallel_size: int = 1,
+) -> None:
+    global _SEQUENCE_PARALLEL_SIZE
+    assert _SEQUENCE_PARALLEL_SIZE is None
+    _SEQUENCE_PARALLEL_SIZE = sequence_parallel_size
+    vllm_initialize_model_parallel(
+        tensor_model_parallel_size, pipeline_model_parallel_size
+    )
+
+
+def sequence_parallel_is_initialized():
+    return _SEQUENCE_PARALLEL_SIZE is not None
+
+
+def get_sequence_parallel_world_size():
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    return _SEQUENCE_PARALLEL_SIZE
+
+
+def get_sequence_parallel_local_rank(rank: int = None):
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    if rank is None:
+        rank = get_tensor_model_parallel_rank()
+    local_rank = rank % _SEQUENCE_PARALLEL_SIZE
+    return local_rank
+
+
+def get_sequence_parallel_global_rank():
+    return get_tensor_model_parallel_rank()
+
+
+def get_sequence_parallel_first_rank(rank: int = None):
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    if rank is None:
+        rank = get_tensor_model_parallel_rank()
+    first_rank = rank // _SEQUENCE_PARALLEL_SIZE * _SEQUENCE_PARALLEL_SIZE
+    return first_rank
+
+
+def get_sequence_parallel_last_rank(rank: int = None):
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    if rank is None:
+        rank = get_tensor_model_parallel_rank()
+    last_rank = (
+        rank // _SEQUENCE_PARALLEL_SIZE * _SEQUENCE_PARALLEL_SIZE
+        + _SEQUENCE_PARALLEL_SIZE
+        - 1
+    )
+    return last_rank
+
+
+def get_sequence_parallel_next_rank(rank: int = None):
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    if rank is None:
+        rank = get_tensor_model_parallel_rank()
+    first_rank = get_sequence_parallel_first_rank(rank)
+    next_rank = first_rank + (rank + 1) % _SEQUENCE_PARALLEL_SIZE
+    return next_rank
+
+
+def get_sequence_parallel_prev_rank(rank: int = None):
+    assert _SEQUENCE_PARALLEL_SIZE is not None
+    if rank is None:
+        rank = get_tensor_model_parallel_rank()
+    first_rank = get_sequence_parallel_first_rank(rank)
+    prev_rank = first_rank + (rank - 1) % _SEQUENCE_PARALLEL_SIZE
+    return prev_rank

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -1,0 +1,74 @@
+from typing import List, Optional
+
+import torch
+from vllm.distributed import initialize_model_parallel as vllm_initialize_model_parallel
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    get_world_group,
+    init_model_parallel_group,
+)
+
+_SP: Optional[GroupCoordinator] = None
+
+
+def get_sp_group():
+    assert _SP is not None, "sequence parallel group is not initialized"
+    return _SP
+
+
+def init_sequence_parallel_group(
+    group_ranks: List[List[int]], local_rank: int, backend: str
+) -> GroupCoordinator:
+    return GroupCoordinator(
+        group_ranks=group_ranks,
+        local_rank=local_rank,
+        torch_distributed_backend=backend,
+        use_pynccl=True,
+    )
+
+
+def initialize_model_parallel(
+    tensor_model_parallel_size: int = 1,
+    pipeline_model_parallel_size: int = 1,
+    sequence_parallel_size: int = 1,
+    backend: Optional[str] = None,
+) -> None:
+    assert torch.distributed.is_initialized()
+    world_size: int = torch.distributed.get_world_size()
+    backend = backend or torch.distributed.get_backend(get_world_group().device_group)
+
+    num_sequence_parallel_groups: int = world_size // sequence_parallel_size
+    global _SP
+    assert _SP is None, "sequence parallel group is already initialized"
+    group_ranks = []
+    for i in range(num_sequence_parallel_groups):
+        ranks = list(
+            range(i * sequence_parallel_size, (i + 1) * sequence_parallel_size)
+        )
+        group_ranks.append(ranks)
+    _SP = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend)
+    vllm_initialize_model_parallel(
+        tensor_model_parallel_size, pipeline_model_parallel_size, backend
+    )
+
+
+def sequence_parallel_is_initialized():
+    return _SP is not None
+
+
+def get_sequence_parallel_world_size():
+    return get_sp_group().world_size
+
+
+def get_sequence_parallel_rank():
+    return get_sp_group().rank_in_group
+
+
+def get_actual_tensor_model_parallel_world_size():
+    return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
+
+
+def get_actual_tensor_model_parallel_rank():
+    return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -43,10 +43,10 @@ def initialize_model_parallel(
     and SP size 2, we have 1 TP group and 4 SP groups:
     SP groups:
         [g0, g1], [g2, g3], [g4, g5], [g6, g7]
-    Their actual TP rank:
+    Their KV TP rank:
         [ 0,  0], [ 1,  1], [ 2,  2], [ 3,  3]
-    In this case, we also say that the actual TP size is 4 (8//2), and gpus in each
-    SP group have actual tp rank from 0 to 3.
+    Given that we replicate KV heads within the same seq parallel group, we also say that
+    the KV TP size is 4 (8//2), and gpus in each SP group have KV-tp rank from 0 to 3.
     """
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
@@ -62,6 +62,7 @@ def initialize_model_parallel(
         )
         group_ranks.append(ranks)
     _SP = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend)
+
     vllm_initialize_model_parallel(
         tensor_model_parallel_size, pipeline_model_parallel_size, backend
     )

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 from vllm.distributed import initialize_model_parallel as vllm_initialize_model_parallel
 from vllm.distributed.parallel_state import (
-    get_tensor_model_parallel_group,
     get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
 )
 
 _SEQUENCE_PARALLEL_SIZE = None
@@ -29,7 +31,7 @@ def get_sequence_parallel_world_size():
     return _SEQUENCE_PARALLEL_SIZE
 
 
-def get_sequence_parallel_local_rank(rank: int = None):
+def get_sequence_parallel_local_rank(rank: Optional[int] = None):
     assert _SEQUENCE_PARALLEL_SIZE is not None
     if rank is None:
         rank = get_tensor_model_parallel_rank()
@@ -41,7 +43,7 @@ def get_sequence_parallel_global_rank():
     return get_tensor_model_parallel_rank()
 
 
-def get_sequence_parallel_first_rank(rank: int = None):
+def get_sequence_parallel_first_rank(rank: Optional[int] = None):
     assert _SEQUENCE_PARALLEL_SIZE is not None
     if rank is None:
         rank = get_tensor_model_parallel_rank()
@@ -49,7 +51,7 @@ def get_sequence_parallel_first_rank(rank: int = None):
     return first_rank
 
 
-def get_sequence_parallel_last_rank(rank: int = None):
+def get_sequence_parallel_last_rank(rank: Optional[int] = None):
     assert _SEQUENCE_PARALLEL_SIZE is not None
     if rank is None:
         rank = get_tensor_model_parallel_rank()
@@ -61,7 +63,7 @@ def get_sequence_parallel_last_rank(rank: int = None):
     return last_rank
 
 
-def get_sequence_parallel_next_rank(rank: int = None):
+def get_sequence_parallel_next_rank(rank: Optional[int] = None):
     assert _SEQUENCE_PARALLEL_SIZE is not None
     if rank is None:
         rank = get_tensor_model_parallel_rank()
@@ -70,10 +72,18 @@ def get_sequence_parallel_next_rank(rank: int = None):
     return next_rank
 
 
-def get_sequence_parallel_prev_rank(rank: int = None):
+def get_sequence_parallel_prev_rank(rank: Optional[int] = None):
     assert _SEQUENCE_PARALLEL_SIZE is not None
     if rank is None:
         rank = get_tensor_model_parallel_rank()
     first_rank = get_sequence_parallel_first_rank(rank)
     prev_rank = first_rank + (rank - 1) % _SEQUENCE_PARALLEL_SIZE
     return prev_rank
+
+
+def get_actual_tensor_model_parallel_world_size():
+    return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
+
+
+def get_actual_tensor_model_parallel_rank():
+    return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -35,6 +35,19 @@ def initialize_model_parallel(
     sequence_parallel_size: int = 1,
     backend: Optional[str] = None,
 ) -> None:
+    """
+    Initialize model parallel groups and sequence parallel groups.
+
+    For sequence parallelism, we partition SP groups within a TP group, and assign
+    gpus with adjacent ranks to the same SP group. For example, with TP size 8
+    and SP size 2, we have 1 TP group and 4 SP groups:
+    SP groups:
+        [g0, g1], [g2, g3], [g4, g5], [g6, g7]
+    Their actual TP rank:
+        [ 0,  0], [ 1,  1], [ 2,  2], [ 3,  3]
+    In this case, we also say that the actual TP size is 4 (8//2), and gpus in each
+    SP group have actual tp rank from 0 to 3.
+    """
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
     backend = backend or torch.distributed.get_backend(get_world_group().device_group)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -3,6 +3,7 @@
 import torch
 from flashinfer.cascade import merge_state
 from torch import nn
+from torch.distributed import P2POp, batch_isend_irecv, irecv, isend
 from vllm.distributed import get_tensor_model_parallel_rank, get_tp_group
 
 from sglang.global_config import global_config
@@ -132,19 +133,36 @@ class RadixAttention(nn.Module):
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)
 
-    def send_kv(self, k, v, my_rank, to_rank):
-        assert k.size() == v.size()
-        tp_group = get_tp_group()
-        tp_group.send_object(k.size(), to_rank)
-        tp_group.send(k, to_rank)
-        tp_group.send(v, to_rank)
+    def launch_sp_comm_ops(self, kv_to_recv, kv_to_send, from_rank, my_rank, to_rank):
+        def _send(handles, group):
+            if my_rank != to_rank:
+                for t in kv_to_send:
+                    handles.append(P2POp(op=isend, tensor=t, peer=to_rank, group=group))
 
-    def recv_kv(self, from_rank, dtype, kv_size):
-        tp_group = get_tp_group()
-        kv_size = tp_group.recv_object(from_rank)
-        k = tp_group.recv(kv_size, dtype, from_rank)
-        v = tp_group.recv(kv_size, dtype, from_rank)
-        return k, v
+        def _recv(handles, group):
+            if my_rank != from_rank:
+                for t in kv_to_recv:
+                    handles.append(
+                        P2POp(op=irecv, tensor=t, peer=from_rank, group=group)
+                    )
+
+        handles = []
+        reqs = []
+        tp_group = get_tp_group().device_group
+        # Interleaving workers for send and recv to avoid deadlock
+        if my_rank % 2 == 0:
+            _send(handles, tp_group)
+            _recv(handles, tp_group)
+        else:
+            _recv(handles, tp_group)
+            _send(handles, tp_group)
+        if handles:
+            reqs = batch_isend_irecv(handles)
+        return reqs
+
+    def wait_sp_comm_ops(self, reqs):
+        for req in reqs:
+            req.wait()
 
     def seq_parallel_extend_forward_triton(
         self, q, k, v, input_metadata: InputMetadata
@@ -159,6 +177,27 @@ class RadixAttention(nn.Module):
     def seq_parallel_extend_forward_flashinfer(
         self, q, k, v, input_metadata: InputMetadata
     ):
+        """Here we adopted a unique parallelization strategy.
+        For each SP worker, we have
+            q tensor: [batch_size, seq_len, q_head_num // SP_SIZE, head_dim]
+            k tensor: [batch_size, seq_len // SP_SIZE, k_head_num, head_dim]
+            v tensor: [batch_size, seq_len // SP_SIZE, v_head_num, head_dim]
+        """
+
+        def get_sp_seq_range(seq_len, sp_rank, sp_size):
+            sp_seq_len = seq_len // sp_size + ((seq_len % sp_size) > sp_rank)
+            stt = sp_rank * (seq_len // sp_size) + min(sp_rank, seq_len % sp_size)
+            end = stt + sp_seq_len
+            return stt, end
+
+        def get_k_shard_shape(batch_size, seq_len, sp_rank, sp_size):
+            sp_seq_len = seq_len // sp_size + ((seq_len % sp_size) > sp_rank)
+            return (batch_size * sp_seq_len, self.tp_k_head_num, self.head_dim)
+
+        def get_v_shard_shape(batch_size, seq_len, sp_rank, sp_size):
+            sp_seq_len = seq_len // sp_size + ((seq_len % sp_size) > sp_rank)
+            return (batch_size * sp_seq_len, self.tp_v_head_num, self.head_dim)
+
         def append_merge_shard(shard_list, o, s):
             if len(shard_list) == 0:
                 shard_list.append((o, s))
@@ -171,14 +210,14 @@ class RadixAttention(nn.Module):
         sp_size = get_sequence_parallel_world_size()
         num_shards = sp_size
         num_iters = sp_size
-        qo_len_per_iter = q.size(1) // num_iters
+        seq_len = q.size(1)
         batch_size = input_metadata.batch_size
 
         # FIXME: k and v should have been sharded and trimmed (padding tokens) so use them directly.
         local_k = k.contiguous().view(-1, self.tp_k_head_num, self.head_dim)
         local_v = v.contiguous().view(-1, self.tp_v_head_num, self.head_dim)
 
-        owned_pids = [rank]
+        owned_sids = [rank]
         owned_shards = [None for _ in range(num_shards)]
         owned_shards[rank] = (local_k, local_v)
         output_shards = [[] for _ in range(num_shards)]
@@ -186,17 +225,31 @@ class RadixAttention(nn.Module):
         # For communication
         to_rank = rank  # which SP worker to send my sequence KV shard to.
         from_rank = rank  # which SP worker to receive the sequence KV shard from.
-        pid = rank  # start from the worker's own shard
+        sid = rank  # start from the worker's own shard
         for _ in range(num_iters):
             to_rank = get_sequence_parallel_next_rank(to_rank)
             from_rank = get_sequence_parallel_prev_rank(from_rank)
-            # FIXME: send-recv communication here
-            # if rank != to_rank:
-            #     print("send", rank, to_rank)
-            #     self.send_kv(local_k, local_v, rank, to_rank)
-            #     print("send done", rank, to_rank)
-            q_shard = q[:, pid * qo_len_per_iter : (pid + 1) * qo_len_per_iter]
-            k_shard, v_shard = owned_shards[pid]
+            # Launch async communication operations
+            if rank != from_rank:
+                # reserve space for kv tensors received from other peers
+                owned_shards[from_rank] = (
+                    torch.empty(
+                        get_k_shard_shape(batch_size, seq_len, from_rank, sp_size),
+                        device=local_k.device,
+                        dtype=local_k.dtype,
+                    ),
+                    torch.empty(
+                        get_v_shard_shape(batch_size, seq_len, from_rank, sp_size),
+                        device=local_v.device,
+                        dtype=local_v.dtype,
+                    ),
+                )
+            comm_reqs = self.launch_sp_comm_ops(
+                owned_shards[from_rank], owned_shards[rank], from_rank, rank, to_rank
+            )
+            q_shard_stt, q_shard_end = get_sp_seq_range(seq_len, sid, sp_size)
+            q_shard = q[:, q_shard_stt:q_shard_end]
+            k_shard, v_shard = owned_shards[sid]
             # Ragged attention computation for self attention within the shard
             o, s = input_metadata.flashinfer_prefill_wrapper_ragged.forward_return_lse(
                 q_shard.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
@@ -206,17 +259,20 @@ class RadixAttention(nn.Module):
                 sm_scale=self.scaling,
                 logits_soft_cap=self.logit_cap,
             )
-            append_merge_shard(output_shards[pid], o, s)
+            append_merge_shard(output_shards[sid], o, s)
             # Paged attention computation for cross shard attention
-            # NOTE: below schedule is for load balancing
-            for existing_pid in owned_pids:
-                if existing_pid == pid:
+            # NOTE: below schedule is for load balancing. Basically, at iteration i,
+            # (i starting from 0), each SP worker will run i paged attentions.
+            for existing_sid in owned_sids:
+                if existing_sid == sid:
                     continue
+                # Due to the causal nature of the attention, swap pids if necessary
                 i, j = (
-                    (existing_pid, pid) if existing_pid > pid else (pid, existing_pid)
+                    (existing_sid, sid) if existing_sid > sid else (sid, existing_sid)
                 )
-                q_data = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
-                # FIXME: should store them into kv cache and use kv cache here.
+                q_shard_stt, q_shard_end = get_sp_seq_range(seq_len, i, sp_size)
+                q_data = q[:, q_shard_stt:q_shard_end]
+                # FIXME (yifan): should store them into kv cache and use kv cache here.
                 kv_data = torch.stack(owned_shards[j], dim=1)
                 o, s = (
                     input_metadata.flashinfer_prefill_wrapper_paged.forward_return_lse(
@@ -229,39 +285,22 @@ class RadixAttention(nn.Module):
                 )
                 append_merge_shard(output_shards[i], o, s)
 
-            # # FIXME: send-recv communication here
-            # if rank != from_rank:
-            #     print("recv", rank, from_rank)
-            #     kv_recved = self.recv_kv(from_rank, k.dtype)
-            #     owned_pids.append(pid)
-            #     owned_shards[pid] = kv_recved
-            # FIXME: here we applied a synchronous communication logic. Need to fix this.
-            if rank % 2 == 0:
-                if rank != to_rank:
-                    self.send_kv(local_k, local_v, rank, to_rank)
-                if rank != from_rank:
-                    kv_recved = self.recv_kv(from_rank, k.dtype, local_k.size())
-                    owned_pids.append(from_rank)
-                    owned_shards[from_rank] = kv_recved
-            else:
-                if rank != from_rank:
-                    kv_recved = self.recv_kv(from_rank, k.dtype, local_k.size())
-                    owned_pids.append(from_rank)
-                    owned_shards[from_rank] = kv_recved
-                if rank != to_rank:
-                    self.send_kv(local_k, local_v, rank, to_rank)
-            pid = from_rank
+            # Wait for async communication to complete
+            self.wait_sp_comm_ops(comm_reqs)
+            if rank != from_rank:
+                owned_sids.append(from_rank)
+            sid = from_rank
 
         # Reshape all o tensors so that we can concatenate along the sequence dimension
         # we must have len(shard_list) == 1 here
         os = [
-            o.view(batch_size, qo_len_per_iter, self.tp_q_head_num, self.head_dim)
+            o.view(batch_size, -1, self.tp_q_head_num, self.head_dim)
             for shard_list in output_shards
             for o, _ in shard_list
         ]
         o = torch.cat(os, dim=1)
 
-        # FIXME: enable kv cache storage after we supoprt it.
+        # FIXME (yifan): enable kv cache storage after we supoprt it.
         # self.store_kv_cache(k, v, input_metadata)
 
         # if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -117,10 +117,10 @@ class RadixAttention(nn.Module):
 
             o, _ = merge_state(o1, s1, o2, s2)
 
-        # self.store_kv_cache(k, v, input_metadata)
+        self.store_kv_cache(k, v, input_metadata)
 
-        # if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:
-        #     torch.cuda.synchronize()
+        if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:
+            torch.cuda.synchronize()
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)
 

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -268,7 +268,7 @@ class RadixAttention(nn.Module):
                 q_data = qs[i]
                 kv_data = torch.stack(owned_shards[j], dim=1)
                 o, s = (
-                    input_metadata.flashinfer_prefill_wrapper_paged.forward_return_lse(
+                    input_metadata.flashinfer_prefill_wrapper_paged_sp.forward_return_lse(
                         q_data.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
                         kv_data.contiguous(),
                         causal=False,

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -3,9 +3,19 @@
 import torch
 from flashinfer.cascade import merge_state
 from torch import nn
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tp_group,
+)
 
 from sglang.global_config import global_config
 from sglang.srt.layers.extend_attention import extend_attention_fwd
+
+from sglang.srt.layers.parallel_utils.parallel_state import (
+    get_sequence_parallel_next_rank,
+    get_sequence_parallel_prev_rank,
+    get_sequence_parallel_world_size,
+)
 from sglang.srt.layers.token_attention import token_attention_fwd
 from sglang.srt.managers.controller.model_runner import ForwardMode, InputMetadata
 from sglang.srt.server import global_server_args_dict
@@ -125,6 +135,149 @@ class RadixAttention(nn.Module):
         )
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)
+
+    def send_kv(self, k, v, my_rank, to_rank):
+        assert k.size() == v.size()
+        tp_group = get_tp_group()
+        tp_group.send_object(k.size(), to_rank)
+        tp_group.send(k, to_rank)
+        tp_group.send(v, to_rank)
+
+    def recv_kv(self, from_rank, dtype, kv_size):
+        tp_group = get_tp_group()
+        kv_size = tp_group.recv_object(from_rank)
+        k = tp_group.recv(kv_size, dtype, from_rank)
+        v = tp_group.recv(kv_size, dtype, from_rank)
+        return k, v
+
+    def seq_parallel_extend_forward_triton(
+        self, q, k, v, input_metadata: InputMetadata
+    ):
+        raise NotImplementedError()
+
+    def seq_parallel_decode_forward_triton(
+        self, q, k, v, input_metadata: InputMetadata
+    ):
+        raise NotImplementedError()
+
+    def seq_parallel_extend_forward_flashinfer(
+        self, q, k, v, input_metadata: InputMetadata
+    ):
+        def append_merge_shard(shard_list, o, s):
+            if len(shard_list) == 0:
+                shard_list.append((o, s))
+            else:
+                o_prev, s_prev = shard_list[-1]
+                o, s = merge_state(o_prev, s_prev, o, s)
+                shard_list[-1] = (o, s)
+
+        rank = get_tensor_model_parallel_rank()
+        sp_size = get_sequence_parallel_world_size()
+        num_shards = sp_size
+        num_iters = sp_size
+        qo_len_per_iter = q.size(1) // num_iters
+        batch_size = input_metadata.batch_size
+
+        # FIXME: k and v should have been sharded and trimmed (padding tokens) so use them directly.
+        local_k = k.contiguous().view(-1, self.tp_k_head_num, self.head_dim)
+        local_v = v.contiguous().view(-1, self.tp_v_head_num, self.head_dim)
+
+        owned_pids = [rank]
+        owned_shards = [None for _ in range(num_shards)]
+        owned_shards[rank] = (local_k, local_v)
+        output_shards = [[] for _ in range(num_shards)]
+
+        # For communication
+        to_rank = rank  # which SP worker to send my sequence KV shard to.
+        from_rank = rank  # which SP worker to receive the sequence KV shard from.
+        pid = rank  # start from the worker's own shard
+        for _ in range(num_iters):
+            to_rank = get_sequence_parallel_next_rank(to_rank)
+            from_rank = get_sequence_parallel_prev_rank(from_rank)
+            # FIXME: send-recv communication here
+            # if rank != to_rank:
+            #     print("send", rank, to_rank)
+            #     self.send_kv(local_k, local_v, rank, to_rank)
+            #     print("send done", rank, to_rank)
+            q_shard = q[:, pid * qo_len_per_iter : (pid + 1) * qo_len_per_iter]
+            k_shard, v_shard = owned_shards[pid]
+            # Ragged attention computation for self attention within the shard
+            o, s = input_metadata.flashinfer_prefill_wrapper_ragged.forward_return_lse(
+                q_shard.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
+                k_shard.contiguous().view(-1, self.tp_k_head_num, self.head_dim),
+                v_shard.contiguous().view(-1, self.tp_v_head_num, self.head_dim),
+                causal=True,
+                sm_scale=self.scaling,
+                logits_soft_cap=self.logit_cap,
+            )
+            append_merge_shard(output_shards[pid], o, s)
+            # Paged attention computation for cross shard attention
+            # NOTE: below schedule is for load balancing
+            for existing_pid in owned_pids:
+                if existing_pid == pid:
+                    continue
+                i, j = (
+                    (existing_pid, pid) if existing_pid > pid else (pid, existing_pid)
+                )
+                q_data = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
+                # FIXME: should store them into kv cache and use kv cache here.
+                kv_data = torch.stack(owned_shards[j], dim=1)
+                o, s = (
+                    input_metadata.flashinfer_prefill_wrapper_paged.forward_return_lse(
+                        q_data.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
+                        kv_data.contiguous(),
+                        causal=False,
+                        sm_scale=self.scaling,
+                        logits_soft_cap=self.logit_cap,
+                    )
+                )
+                append_merge_shard(output_shards[i], o, s)
+
+            # # FIXME: send-recv communication here
+            # if rank != from_rank:
+            #     print("recv", rank, from_rank)
+            #     kv_recved = self.recv_kv(from_rank, k.dtype)
+            #     owned_pids.append(pid)
+            #     owned_shards[pid] = kv_recved
+            # FIXME: here we applied a synchronous communication logic. Need to fix this.
+            if rank % 2 == 0:
+                if rank != to_rank:
+                    self.send_kv(local_k, local_v, rank, to_rank)
+                if rank != from_rank:
+                    kv_recved = self.recv_kv(from_rank, k.dtype, local_k.size())
+                    owned_pids.append(from_rank)
+                    owned_shards[from_rank] = kv_recved
+            else:
+                if rank != from_rank:
+                    kv_recved = self.recv_kv(from_rank, k.dtype, local_k.size())
+                    owned_pids.append(from_rank)
+                    owned_shards[from_rank] = kv_recved
+                if rank != to_rank:
+                    self.send_kv(local_k, local_v, rank, to_rank)
+            pid = from_rank
+
+        # Reshape all o tensors so that we can concatenate along the sequence dimension
+        # we must have len(shard_list) == 1 here
+        os = [
+            o.view(batch_size, qo_len_per_iter, self.tp_q_head_num, self.head_dim)
+            for shard_list in output_shards
+            for o, _ in shard_list
+        ]
+        o = torch.cat(os, dim=1)
+
+        # FIXME: enable kv cache storage after we supoprt it.
+        # self.store_kv_cache(k, v, input_metadata)
+
+        # if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:
+        #     torch.cuda.synchronize()
+
+        return o.view(-1, self.tp_q_head_num * self.head_dim)
+
+    def seq_parallel_decode_forward_flashinfer(
+        self, q, k, v, input_metadata: InputMetadata
+    ):
+        # TODO: implementation
+        raise NotImplementedError()
 
     def forward(self, q, k, v, input_metadata: InputMetadata):
         k = k.view(-1, self.tp_k_head_num, self.head_dim)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -117,10 +117,10 @@ class RadixAttention(nn.Module):
 
             o, _ = merge_state(o1, s1, o2, s2)
 
-        self.store_kv_cache(k, v, input_metadata)
+        # self.store_kv_cache(k, v, input_metadata)
 
-        if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:
-            torch.cuda.synchronize()
+        # if input_metadata.total_num_tokens >= global_config.layer_sync_threshold:
+        #     torch.cuda.synchronize()
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)
 
@@ -187,6 +187,7 @@ class RadixAttention(nn.Module):
             k tensor: [batch_size * seq_len // SP_SIZE, k_head_num, head_dim]
             v tensor: [batch_size * seq_len // SP_SIZE, v_head_num, head_dim]
         """
+
         def get_k_shard_shape(token_num, sp_rank, sp_size):
             sp_token_num = token_num // sp_size + ((token_num % sp_size) > sp_rank)
             return (sp_token_num, self.tp_k_head_num, self.head_dim)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -220,6 +220,7 @@ class RadixAttention(nn.Module):
         # Because we haven't partitioned k and v along the sequence dimension
         # (dim 0 in k and v tensors), here we manually select the corresponding
         # shard for simulation.
+        q = q.view(-1, self.tp_q_head_num, self.head_dim)
         k = k[rank]
         v = v[rank]
 

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -209,7 +209,7 @@ class RadixAttention(nn.Module):
         num_shards = sp_size
         num_iters = sp_size
         token_num = input_metadata.total_num_tokens
-        # FIXME: k and v should have been sharded and trimmed (padding tokens) so use them directly.
+        # k and v should have been sharded and trimmed (padding tokens) here so use them directly.
         local_k = k.contiguous().view(-1, self.tp_k_head_num, self.head_dim)
         local_v = v.contiguous().view(-1, self.tp_v_head_num, self.head_dim)
 
@@ -283,9 +283,8 @@ class RadixAttention(nn.Module):
             if rank != from_rank:
                 owned_sids.append(from_rank)
             sid = from_rank
-        # TODO(yifan): double check this
-        # Reshape all o tensors so that we can concatenate along the sequence dimension
-        # we must have len(shard_list) == 1 here
+
+        # Concat all output shards along the sequence dimension.
         os = [
             o.view(-1, self.tp_q_head_num, self.head_dim)
             for shard_list in output_shards

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -182,9 +182,9 @@ class RadixAttention(nn.Module):
     ):
         """Here we adopted a unique parallelization strategy.
         For each SP worker, we have
-            q tensor: [batch_size, seq_len, q_head_num // SP_SIZE, head_dim]
-            k tensor: [batch_size, seq_len // SP_SIZE, k_head_num, head_dim]
-            v tensor: [batch_size, seq_len // SP_SIZE, v_head_num, head_dim]
+            q tensor: [batch_size * seq_len, q_head_num // SP_SIZE, head_dim]
+            k tensor: [batch_size * seq_len // SP_SIZE, k_head_num, head_dim]
+            v tensor: [batch_size * seq_len // SP_SIZE, v_head_num, head_dim]
         """
 
         def get_sp_seq_range(seq_len, sp_rank, sp_size):
@@ -213,8 +213,15 @@ class RadixAttention(nn.Module):
         sp_size = get_sequence_parallel_world_size()
         num_shards = sp_size
         num_iters = sp_size
-        seq_len = q.size(1)
         batch_size = input_metadata.batch_size
+        # FIXME (yifan): Below are hardcoded for debugging purpose. Should fix
+        # this with correct layout.
+        seq_len = q.size(0) * q.size(1)
+        # Because we haven't partitioned k and v along the sequence dimension
+        # (dim 0 in k and v tensors), here we manually select the corresponding
+        # shard for simulation.
+        k = k[rank]
+        v = v[rank]
 
         # FIXME: k and v should have been sharded and trimmed (padding tokens) so use them directly.
         local_k = k.contiguous().view(-1, self.tp_k_head_num, self.head_dim)
@@ -251,7 +258,7 @@ class RadixAttention(nn.Module):
                 owned_shards[from_rank], owned_shards[rank], from_rank, rank, to_rank
             )
             q_shard_stt, q_shard_end = get_sp_seq_range(seq_len, sid, sp_size)
-            q_shard = q[:, q_shard_stt:q_shard_end]
+            q_shard = q[q_shard_stt:q_shard_end]
             k_shard, v_shard = owned_shards[sid]
             # Ragged attention computation for self attention within the shard
             o, s = input_metadata.flashinfer_prefill_wrapper_ragged.forward_return_lse(
@@ -274,7 +281,7 @@ class RadixAttention(nn.Module):
                     (existing_sid, sid) if existing_sid > sid else (sid, existing_sid)
                 )
                 q_shard_stt, q_shard_end = get_sp_seq_range(seq_len, i, sp_size)
-                q_data = q[:, q_shard_stt:q_shard_end]
+                q_data = q[q_shard_stt:q_shard_end]
                 # FIXME (yifan): should store them into kv cache and use kv cache here.
                 kv_data = torch.stack(owned_shards[j], dim=1)
                 o, s = (
@@ -293,15 +300,11 @@ class RadixAttention(nn.Module):
             if rank != from_rank:
                 owned_sids.append(from_rank)
             sid = from_rank
-
+        # TODO(yifan): double check this
         # Reshape all o tensors so that we can concatenate along the sequence dimension
         # we must have len(shard_list) == 1 here
-        os = [
-            o.view(batch_size, -1, self.tp_q_head_num, self.head_dim)
-            for shard_list in output_shards
-            for o, _ in shard_list
-        ]
-        o = torch.cat(os, dim=1)
+        os = [o for shard_list in output_shards for o, _ in shard_list]
+        o = torch.cat(os, dim=0)
 
         # FIXME (yifan): enable kv cache storage after we supoprt it.
         # self.store_kv_cache(k, v, input_metadata)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -92,6 +92,9 @@ class RadixAttention(nn.Module):
         return o
 
     def extend_forward_flashinfer(self, q, k, v, input_metadata: InputMetadata):
+        if input_metadata.sp_size > 1:
+            return self.seq_parallel_extend_forward_flashinfer(q, k, v, input_metadata)
+
         o1, s1 = input_metadata.flashinfer_prefill_wrapper_ragged.forward_return_lse(
             q.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
             k.contiguous().view(-1, self.tp_k_head_num, self.head_dim),

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -3,14 +3,10 @@
 import torch
 from flashinfer.cascade import merge_state
 from torch import nn
-from vllm.distributed import (
-    get_tensor_model_parallel_rank,
-    get_tp_group,
-)
+from vllm.distributed import get_tensor_model_parallel_rank, get_tp_group
 
 from sglang.global_config import global_config
 from sglang.srt.layers.extend_attention import extend_attention_fwd
-
 from sglang.srt.layers.parallel_utils.parallel_state import (
     get_sequence_parallel_next_rank,
     get_sequence_parallel_prev_rank,

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -880,7 +880,6 @@ class InputMetadata:
         sp_rank = model_runner.sp_rank
         sp_size = model_runner.sp_size
         if sp_size > 1:
-            # FIXME: haven't supported cuda graph yet.
             # During the runtime, we should use positions[local_token_indices]
             # to get positions for each SP shard.
             prefix_lens = prefix_lens if prefix_lens is not None else 0
@@ -977,6 +976,7 @@ def init_flashinfer_args(
     )
     head_dim = model_runner.model_config.head_dim
     batch_size = len(req_pool_indices)
+    prefix_lens = prefix_lens if prefix_lens is not None else torch.zeros_like(seq_lens)
     extend_lens = seq_lens - prefix_lens
     seq_lens = torch.ceil(seq_lens / model_runner.sp_size).to(torch.int32)
     prefix_lens = torch.ceil(prefix_lens / model_runner.sp_size).to(torch.int32)

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -901,6 +901,9 @@ class InputMetadata:
                 sp_local_token_length = _get_local_token_nums_new(
                     sp_rank, sp_size, extend_seq_lens_cpu
                 )
+            # Convert positions to SP layout
+            normal_to_sp_indices = np.argsort(sp_to_normal_indices)
+            positions = positions[normal_to_sp_indices]
         else:
             sp_to_normal_indices = np.arange(positions.numel())
             _debug_normal_to_sp_metadata = None

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -334,8 +334,9 @@ class Batch:
         # Handle prefix
         # Note: The flatten input ids with Sequence Parallel is in form of:
         # [req_0_sp_0, req_1_sp_0, ... req_n_sp_0,
-        #   req_0_sp_1, ..., req_n_sp_1, padding_sp_1,
+        #  req_0_sp_1, req_1_sp_1, ..., req_n_sp_1,
         #   ...
+        #  req_0_sp_m, req_0_padding, req_1_sp_m, req_1_padding, ...]
         # ]
         # The padding is for collection primitives which needs each candidate to
         # have the same size. Since we don't expect too many requests in SP,
@@ -354,11 +355,15 @@ class Batch:
             )
 
         req_pool_indices_cpu = req_pool_indices.cpu().numpy()
+        num_padding_tokens = _get_num_padding_tokens(self.sp_size, [
+            len(ids) for ids in input_ids
+        ])
         for i in range(bs):
             for sp_rank in range(self.sp_size):
                 ids = input_ids[i]
-                local_slice = _get_local_token_slices(sp_rank, self.sp_size, len(ids))
+                local_slice = _get_local_token_slices_new(sp_rank, self.sp_size, len(ids))
                 flatten_input_ids[sp_rank].extend(ids[local_slice])
+            flatten_input_ids[-1].extend([0] * num_padding_tokens[i])
             extend_lens.append(len(input_ids[i]))
 
             if len(prefix_indices[i]) == 0:
@@ -370,11 +375,8 @@ class Batch:
                 ] = prefix_indices[i]
 
             seq_lens.append(prefix_lens[-1] + extend_lens[-1])
-        # For sequence parallel, add padding zeros for each rank.
-        padded_sp_len = max(len(ids) for ids in flatten_input_ids)
-        for flatten_ids in flatten_input_ids:
-            if len(flatten_ids) < padded_sp_len:
-                flatten_ids.extend([0] * (padded_sp_len - len(flatten_ids)))
+        # Already padded at the last shard of each request.
+        padded_sp_len = len(flatten_input_ids[0])
         flatten_input_ids = list(itertools.chain(*flatten_input_ids))
         self.padded_sp_len = padded_sp_len
 
@@ -386,7 +388,7 @@ class Batch:
         if self.sp_size > 1:
             extend_seq_lens = seq_lens - prefix_lens
             # FIXME(yonghao): _extend_num_tokens -> extend_num_tokens once kv cache store is ready for SP
-            extend_local_token_nums = _get_local_token_nums(
+            extend_local_token_nums = _get_local_token_nums_new(
                 self.sp_rank, self.sp_size, extend_seq_lens
             )
             _extend_num_tokens = int(np.sum(extend_local_token_nums))
@@ -804,7 +806,6 @@ class InputMetadata:
     # For Sequence Parallel
     sp_rank: int = None
     sp_size: int = None
-    local_token_indices: np.ndarray = None
     sp_to_normal_indices: np.ndarray = None
     sp_local_token_length: int = None
     _debug_normal_to_sp_metadata: Optional[List[np.ndarray]] = None
@@ -877,23 +878,19 @@ class InputMetadata:
             prefix_lens = prefix_lens if prefix_lens is not None else 0
             extend_seq_lens_cpu = (seq_lens - prefix_lens).cpu().numpy()
             if forward_mode == ForwardMode.DECODE:
-                local_token_indices = get_decode_indices(
-                    sp_rank, sp_size, extend_seq_lens_cpu
-                )
                 sp_to_normal_indices = sp_to_normal_indices_decode(
                     sp_size, extend_seq_lens_cpu, padded_sp_len
                 )
+                _debug_normal_to_sp_metadata = _debug_normal_to_sp_indices_decode(
+                    forward_mode, sp_size, extend_seq_lens_cpu
+                )
             else:
-                extend_start_loc_cpu = extend_start_loc.cpu().numpy()
-                local_token_indices = get_prefill_indices(
-                    sp_rank, sp_size, extend_seq_lens_cpu, extend_start_loc_cpu
-                )
                 sp_to_normal_indices = sp_to_normal_indices_prefill(
-                    sp_size, extend_seq_lens_cpu, padded_sp_len
+                    sp_size, extend_seq_lens_cpu
                 )
-            _debug_normal_to_sp_metadata = _debug_normal_to_sp_indices(
-                forward_mode, sp_size, extend_seq_lens_cpu, padded_sp_len
-            )
+                _debug_normal_to_sp_metadata = _debug_normal_to_sp_indices_prefill(
+                    forward_mode, sp_size, extend_seq_lens_cpu
+                )
         else:
             local_token_indices = np.arange(positions.numel())
             sp_to_normal_indices = np.arange(positions.numel())
@@ -920,7 +917,6 @@ class InputMetadata:
             flashinfer_decode_wrapper=model_runner.flashinfer_decode_wrapper,
             sp_rank=sp_rank,
             sp_size=sp_size,
-            local_token_indices=local_token_indices,
             sp_to_normal_indices=sp_to_normal_indices,
             sp_local_token_length=sp_local_token_length,
             _debug_normal_to_sp_metadata=_debug_normal_to_sp_metadata,
@@ -1026,32 +1022,17 @@ def init_triton_args(forward_mode, seq_lens, prefix_lens):
     return max_seq_len, max_extend_len, start_loc, prefix_lens
 
 
-def get_prefill_indices(
-    sp_rank, sp_size, extend_seq_lens: np.ndarray, extend_start_loc
-):
-    """
-    Get indices from the normal layout to the sequence parallel layout of all
-    requests.
-    """
-    # For the first few ranks, they have one more token to compute
-    sp_req_lens = _get_local_token_nums(sp_rank, sp_size, extend_seq_lens)
-    # the offset of each request in the batch. Only the first few ranks may get
-    # 1 more token (for each). For sp_rank=r, therere r peers ahread (0-based),
-    # each will get one token
-    sp_in_req_offset = extend_seq_lens // sp_size * sp_rank + np.clip(
-        extend_seq_lens % sp_size, a_min=None, a_max=sp_rank
-    )
-    sp_req_start = extend_start_loc + sp_in_req_offset
-    sp_indices = np.concatenate(
-        [np.arange(s, s + l) for s, l in zip(sp_req_start, sp_req_lens)]
-    )
-    return sp_indices
-
-
-def _get_local_token_nums(sp_rank, sp_size, extend_seq_lens: Union[int, np.ndarray]):
+def _get_local_token_nums_new(sp_rank, sp_size, extend_seq_lens: Union[int, np.ndarray]):
     """Get the number of tokens in this SP. Padding is not considered."""
-    has_remainder = (extend_seq_lens % sp_size) > sp_rank
-    return extend_seq_lens // sp_size + has_remainder
+    padded_size = np.ceil(extend_seq_lens / sp_size)
+    return (padded_size if sp_rank != sp_size - 1
+            else extend_seq_lens - (sp_size - 1) * padded_size)
+
+
+def _get_num_padding_tokens(sp_size, extend_seq_lens: np.ndarray):
+    """Get the number of tokens padded for SP."""
+    padded_size = np.ceil(extend_seq_lens / sp_size)
+    return sp_size * padded_size - extend_seq_lens
 
 
 def get_decode_indices(sp_rank, sp_size, seq_lens: np.ndarray, offset=0):
@@ -1059,32 +1040,29 @@ def get_decode_indices(sp_rank, sp_size, seq_lens: np.ndarray, offset=0):
     return np.nonzero((seq_lens % sp_size) == sp_rank)[0] + offset
 
 
-def _get_local_token_slices(sp_rank, sp_size, seq_len: int):
+def _get_local_token_slices_new(sp_rank, sp_size, seq_len: int):
     """Get the SP local slice for a single request's extended input ids."""
-    start = seq_len // sp_size * sp_rank + min(seq_len % sp_size, sp_rank)
-    length = _get_local_token_nums(sp_rank, sp_size, seq_len)
+    start = np.ceil(seq_len / sp_size) * sp_rank
+    length = _get_local_token_nums_new(sp_rank, sp_size, seq_len)
     return slice(start, start + length)
 
 
 def sp_to_normal_indices_prefill(
-    sp_size, extend_seq_lens: np.ndarray, padded_sp_len: int
+    sp_size, extend_seq_lens: np.ndarray
 ):
     """
     Indices from the Sequence Parallel layout (padded) to the normal layout.
     """
-    indices = []
-    sp_offset = [padded_sp_len * sp_rank for sp_rank in range(sp_size)]
-    sp_local_token_nums = [
-        _get_local_token_nums(sp_rank, sp_size, extend_seq_lens)
-        for sp_rank in range(sp_size)
-    ]
-    for req_id in range(len(extend_seq_lens)):
-        for sp_rank in range(sp_size):
-            sp_len = int(sp_local_token_nums[sp_rank][req_id])
-            sp_my_offset = sp_offset[sp_rank]
-            indices.extend(range(sp_my_offset, sp_my_offset + sp_len))
-            sp_offset[sp_rank] += sp_len
-    return np.asarray(indices)
+    sp_seq_lens = np.ceil(extend_seq_lens / sp_size)
+    sp_seq_offset = np.concatenate([np.asarray([0], dtype=np.int32),
+                                    np.cumsum(sp_seq_lens[:-1])])
+    sp_arange = np.arange(sp_size).reshape(-1, 1)
+    for i in range(range(len(extend_seq_lens))):
+        sp_idx = np.arange(sp_seq_lens[i]).reshape(1,-1).repeat(sp_size, axis=0)
+        sp_idx = (sp_idx + sp_seq_offset[i] * sp_arange).reshpae(-1)
+        indices.append(sp_idx)
+    indices = np.concatenate(indices)
+    return indices
 
 
 def sp_to_normal_indices_decode(sp_size, seq_lens_cpu: np.ndarray, padded_sp_len: int):
@@ -1100,19 +1078,38 @@ def sp_to_normal_indices_decode(sp_size, seq_lens_cpu: np.ndarray, padded_sp_len
     return req_sp_offset
 
 
-def _debug_normal_to_sp_indices(mode, sp_size, seq_lens, sp_padded_len):
+def _debug_normal_to_sp_indices_decode(sp_size, seq_lens):
     """(Debug only) Indices from normal layout to the SP layout (padded)."""
-    get_indices_fn = (
-        get_decode_indices if mode == ForwardMode.DECODE else get_prefill_indices
-    )
-    offset = (
-        0
-        if mode == ForwardMode.DECODE
-        else np.concatenate([np.asarray([0], dtype=np.int32), np.cumsum(seq_lens[:-1])])
-    )
     indices = [
-        get_indices_fn(sp_rank, sp_size, seq_lens, offset) for sp_rank in range(sp_size)
+        get_decode_indices(sp_rank, sp_size, seq_lens) for sp_rank in range(sp_size)
     ]
+    indices = [(np.arange(len(idxs)), idxs) for idxs in indices]
+    return indices
+
+
+def _debug_normal_to_sp_indices_prefill(sp_size, seq_lens):
+    """(Debug only) Indices from normal layout to the SP layout (padded)."""
+    indices = []
+    sp_seq_lens = np.ceil(seq_lens / sp_size)
+    seq_offset = np.concatenate([np.asarray([0], dtype=np.int32),
+                                 np.cumsum(seq_lens[:-1])])
+    sp_seq_offset = np.concatenate([np.asarray([0], dtype=np.int32),
+                                    np.cumsum(sp_seq_lens[:-1])])
+    for sp_rank in range(sp_size):
+        start_idx = seq_offset + sp_seq_lens * sp_rank
+        end_idx = np.min(seq_offset + sp_seq_lens * (sp_rank + 1), seq_lens)
+        normal_layout_idx = (np.concatenate(
+            [np.arange(start_idx[i], end_idx[i]) for i in range(len(seq_lens))]
+        ))
+        if sp_rank == sp_size - 1:
+            length = end_idx - start_idx
+            target_layout_idx = np.concatenate([
+                np.arange(sp_seq_offset[i], sp_seq_offset[i] + length[i])
+                for i in range(len(seq_lens))
+            ])
+        else:
+            target_layout_idx = np.arange(len(normal_layout_idx))
+        indices.append((target_layout_idx, normal_layout_idx))
     return indices
 
 

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -964,8 +964,12 @@ def init_flashinfer_args(
         for i in range(batch_size):
             seq_len = seq_lens_cpu[i]
             prefix_len = prefix_lens_cpu[i]
-            seq_lens_cpu[i] = seq_len // model_runner.sp_size + (seq_len % model_runner.sp_size > model_runner.sp_rank)
-            prefix_lens_cpu[i] = prefix_len // model_runner.sp_size + (prefix_len % model_runner.sp_size > model_runner.sp_rank)
+            seq_lens_cpu[i] = seq_len // model_runner.sp_size + (
+                seq_len % model_runner.sp_size > model_runner.sp_rank
+            )
+            prefix_lens_cpu[i] = prefix_len // model_runner.sp_size + (
+                prefix_len % model_runner.sp_size > model_runner.sp_rank
+            )
         seq_lens = torch.tensor(seq_lens_cpu, dtype=torch.int32, device="cuda")
         prefix_lens = torch.tensor(prefix_lens_cpu, dtype=torch.int32, device="cuda")
         paged_kernel_lens = prefix_lens

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -904,18 +904,16 @@ class InputMetadata:
                 sp_local_token_length = _get_local_token_nums_new(
                     sp_rank, sp_size, extend_seq_lens_cpu
                 )
-            # Convert positions to SP layout and add padding zeros.
-            normal_to_sp_indices = np.argsort(sp_to_normal_indices)
-            positions = positions[normal_to_sp_indices]
-            positions = _add_padding_zeros(positions, extend_seq_lens_cpu, sp_size)
-            # Add padding zeros to out_cache_loc and write KV of padded tokens
-            # to slot 0 (reserved for dummy output).
-            if (
-                sp_rank == sp_size - 1
-            ):  # Only the last SP shard may contain padding tokens
-                out_cache_loc = _add_padding_zeros(
-                    out_cache_loc, extend_seq_lens_cpu, sp_size, True
-                )
+                # Convert positions to SP layout and add padding zeros.
+                normal_to_sp_indices = np.argsort(sp_to_normal_indices)
+                positions = positions[normal_to_sp_indices]
+                positions = _add_padding_zeros(positions, extend_seq_lens_cpu, sp_size)
+                # Add padding zeros to out_cache_loc and write KV of padded tokens that may
+                # exist in the last SP shard to slot 0 (reserved for dummy output).
+                if sp_rank == sp_size - 1:
+                    out_cache_loc = _add_padding_zeros(
+                        out_cache_loc, extend_seq_lens_cpu, sp_size, True
+                    )
         else:
             sp_to_normal_indices = np.arange(positions.numel())
             _debug_normal_to_sp_metadata = None

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -610,7 +610,7 @@ class Batch:
             if len(flatten_ids) < padded_sp_len:
                 flatten_ids.extend([0] * (padded_sp_len - len(flatten_ids)))
         self.padded_sp_len = padded_sp_len
-        
+
         input_ids = itertools.chain(input_ids_sp)
         self.input_ids = torch.tensor(input_ids, dtype=torch.int32, device="cuda")
         self.prefix_lens = None
@@ -794,9 +794,9 @@ class InputMetadata:
     # For Sequence Parallel
     sp_rank: int = None
     sp_size: int = None
-    local_token_indices: np.ndarray
-    sp_to_normal_indices: np.ndarray
-    sp_local_token_length: int
+    local_token_indices: np.ndarray = None
+    sp_to_normal_indices: np.ndarray = None
+    sp_local_token_length: int = None
 
     @classmethod
     def create(

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -935,6 +935,10 @@ def init_flashinfer_args(
     head_dim = model_runner.model_config.head_dim
     batch_size = len(req_pool_indices)
 
+    # FIXME (yifan): these are hardcoded values for debugging. Fix them use the real layout.
+    seq_lens = seq_lens // model_runner.sp_size
+    prefix_lens = prefix_lens // model_runner.sp_size
+
     if forward_mode == ForwardMode.DECODE:
         paged_kernel_lens = seq_lens
     else:

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -631,8 +631,8 @@ class Batch:
             self.tree_cache.pretty_print()
             exit()
 
-        if self.sp_size > 1:
-            return  # FIXME(yonghao): remove it once SP kv cache store is ready
+        if self.sp_size > 1 and False:
+            # FIXME(yonghao): enable this branch once SP kv cache store is ready
             local_req_indices = self.req_pool_indices[sp_local_indices]
             # NOTE(yonghao): here the seqlen is still the total seq len but not
             # the local lens

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -385,11 +385,10 @@ class Batch:
         extend_num_tokens = seq_lens.sum() - prefix_lens.sum()
         if self.sp_size > 1:
             extend_seq_lens = seq_lens - prefix_lens
-            # FIXME(yonghao): _extend_num_tokens -> extend_num_tokens once kv cache store is ready for SP
             extend_local_token_nums = _get_local_token_nums(
                 self.sp_rank, self.sp_size, extend_seq_lens
             )
-            _extend_num_tokens = int(np.sum(extend_local_token_nums))
+            extend_num_tokens = int(np.sum(extend_local_token_nums))
 
         out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
         if out_cache_loc is None:
@@ -405,8 +404,7 @@ class Batch:
         for i in range(bs):
             extend_len = extend_lens[i]
             if self.sp_size > 1:
-                # FIXME(yonghao): _extend_len > extend_len once SP Attn is ready
-                _extend_len = extend_local_token_nums[i]
+                extend_len = extend_local_token_nums[i]
             self.req_to_token_pool.req_to_token[req_pool_indices_cpu[i]][
                 prefix_lens[i] : prefix_lens[i] + extend_len
             ] = out_cache_loc[pt : pt + extend_len]

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -949,7 +949,9 @@ def init_flashinfer_args(
     num_qo_heads = model_runner.model_config.num_attention_heads // model_runner.tp_size
     # NOTE (yifan): we partitioned K and V along both TP and SP dimensions.
     # And here tp_size represents actual TP size * SP size.
-    num_kv_heads = model_runner.model_config.get_num_kv_heads(model_runner.tp_size // model_runner.sp_size)
+    num_kv_heads = model_runner.model_config.get_num_kv_heads(
+        model_runner.tp_size // model_runner.sp_size
+    )
     head_dim = model_runner.model_config.head_dim
     batch_size = len(req_pool_indices)
 
@@ -980,7 +982,9 @@ def init_flashinfer_args(
             dim=0,
         ).contiguous()
     else:
-        kv_indices = torch.arange(0, torch.sum(seq_lens), dtype=torch.int32, device="cuda")
+        kv_indices = torch.arange(
+            0, torch.sum(seq_lens), dtype=torch.int32, device="cuda"
+        )
         kv_last_page_len = torch.ones((batch_size,), dtype=torch.int32, device="cuda")
 
     if forward_mode == ForwardMode.DECODE:

--- a/python/sglang/srt/managers/controller/infer_batch.py
+++ b/python/sglang/srt/managers/controller/infer_batch.py
@@ -971,7 +971,7 @@ def init_flashinfer_args(
     """Init auxiliary variables for FlashInfer attention backend."""
     num_qo_heads = model_runner.model_config.num_attention_heads // model_runner.tp_size
     # NOTE (yifan): we partitioned K and V along both TP and SP dimensions.
-    # And here tp_size represents actual TP size * SP size.
+    # And here tp_size represents KV-TP size * SP size.
     num_kv_heads = model_runner.model_config.get_num_kv_heads(
         model_runner.tp_size // model_runner.sp_size
     )

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -17,15 +17,12 @@ from flashinfer import (
 from flashinfer.decode import _grouped_size_compiled_for_decode_kernels
 from vllm.config import DeviceConfig, LoadConfig
 from vllm.config import ModelConfig as VllmModelConfig
-from vllm.distributed import (
-    get_tp_group,
-    init_distributed_environment,
-    initialize_model_parallel,
-)
+from vllm.distributed import get_tp_group, init_distributed_environment
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import ModelRegistry
 
 from sglang.global_config import global_config
+from sglang.srt.layers.parallel_utils.parallel_state import initialize_model_parallel
 from sglang.srt.managers.controller.infer_batch import Batch, ForwardMode, InputMetadata
 from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
 from sglang.srt.server_args import ServerArgs
@@ -83,7 +80,10 @@ class ModelRunner:
             local_rank=self.gpu_id,
             distributed_init_method=nccl_init_method,
         )
-        initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
+        initialize_model_parallel(
+            tensor_model_parallel_size=self.tp_size,
+            sequence_parallel_size=self.sp_size,
+        )
         self.tp_group = get_tp_group()
         total_gpu_memory = get_available_gpu_memory(
             self.gpu_id, distributed=self.tp_size > 1

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -148,10 +148,10 @@ class ModelRunner:
         available_gpu_memory = get_available_gpu_memory(
             self.gpu_id, distributed=self.tp_size > 1
         )
-        # Attention uses both TP and SP -- (actual TP size, SP size)
-        actual_tp_size = self.tp_size // self.sp_size
+        # Attention uses both TP and SP -- (KV-TP size, SP size)
+        kv_tp_size = self.tp_size // self.sp_size
         head_dim = self.model_config.head_dim
-        head_num = self.model_config.get_num_kv_heads(actual_tp_size)
+        head_num = self.model_config.get_num_kv_heads(kv_tp_size)
         cell_size = (
             head_num
             * head_dim
@@ -187,12 +187,12 @@ class ModelRunner:
             self.model_config.context_len + 8,
         )
 
-        # Attention uses both TP and SP -- (actual TP size, SP size)
-        actual_tp_size = self.tp_size // self.sp_size
+        # Attention uses both TP and SP -- (KV-TP size, SP size)
+        kv_tp_size = self.tp_size // self.sp_size
         self.token_to_kv_pool = TokenToKVPool(
             self.max_total_num_tokens,
             dtype=self.dtype,
-            head_num=self.model_config.get_num_kv_heads(actual_tp_size),
+            head_num=self.model_config.get_num_kv_heads(kv_tp_size),
             head_dim=self.model_config.head_dim,
             layer_num=self.model_config.num_hidden_layers,
         )

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -17,15 +17,12 @@ from flashinfer import (
 from flashinfer.decode import _grouped_size_compiled_for_decode_kernels
 from vllm.config import DeviceConfig, LoadConfig
 from vllm.config import ModelConfig as VllmModelConfig
-from vllm.distributed import (
-    get_tp_group,
-    init_distributed_environment,
-    initialize_model_parallel,
-)
+from vllm.distributed import get_tp_group, init_distributed_environment
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import ModelRegistry
 
 from sglang.global_config import global_config
+from sglang.srt.layers.parallel_utils import initialize_model_parallel
 from sglang.srt.managers.controller.infer_batch import Batch, ForwardMode, InputMetadata
 from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
 from sglang.srt.server_args import ServerArgs
@@ -83,7 +80,9 @@ class ModelRunner:
             local_rank=self.gpu_id,
             distributed_init_method=nccl_init_method,
         )
-        initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
+        initialize_model_parallel(
+            tensor_model_parallel_size=self.tp_size, sequence_parallel_size=self.sp_size
+        )
         self.tp_group = get_tp_group()
         total_gpu_memory = get_available_gpu_memory(
             self.gpu_id, distributed=self.tp_size > 1

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -178,10 +178,17 @@ class ModelRunner:
             ),
             self.model_config.context_len + 8,
         )
+        if self.tp_size % self.sp_size != 0:
+            raise ValueError(
+                f"Invalid sequence parallel configuration. tp_size={self.tp_size} "
+                f"must be divisible by sp_size={self.sp_size}"
+            )
+        # Attention uses both TP and SP -- (actual TP size, SP size)
+        actual_tp_size = self.tp_size // self.sp_size
         self.token_to_kv_pool = TokenToKVPool(
             self.max_total_num_tokens,
             dtype=self.dtype,
-            head_num=self.model_config.get_num_kv_heads(self.tp_size),
+            head_num=self.model_config.get_num_kv_heads(actual_tp_size),
             head_dim=self.model_config.head_dim,
             layer_num=self.model_config.num_hidden_layers,
         )

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -183,14 +183,17 @@ class LlamaAttention(nn.Module):
             # FIXME(yonghao): remove once attn kernel is ready
             for _, idxs in enumerate(input_metadata._debug_normal_to_sp_metadata):
                 print(self.sp_rank, idxs, q_head_idxes)
-                qs.append(q[idxs].view(-1, self.total_num_heads, self.head_dim)[:, q_head_idxes])
+                qs.append(
+                    q[idxs].view(-1, self.total_num_heads, self.head_dim)[
+                        :, q_head_idxes
+                    ]
+                )
                 ks.append(k[idxs])
                 vs.append(v[idxs])
             q = qs
             k = ks
             v = vs
 
-        print("before attn", self.sp_rank, q.shape, k.shape, v.shape)
         attn_output = self.attn(q, k, v, input_metadata)
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -158,8 +158,8 @@ class LlamaAttention(nn.Module):
                 input_metadata.sp_size, -1, *ori_hidden_states.shape[1:]
             )
             for sp_rank, idxs in enumerate(input_metadata._debug_normal_to_sp_metadata):
-                sp_real_vals = output[idxs]
-                output_sp[sp_rank][: sp_real_vals.shape[0]] = sp_real_vals
+                tgt_idx, src_idx = idxs
+                output_sp[sp_rank][tgt_idx] = output[src_idx]
             output = output_sp.reshape(ori_hidden_states.shape).contiguous()
         return output
 

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -169,7 +169,12 @@ class LlamaAttention(nn.Module):
         # FIXME (yifan): hardcoded for now. Should fix q_proj to avoid all gather
         # and q.shape should be [sp_size, token_num_per_sp, num_heads_per_sp * head_dim]
         q = q.view(-1, self.hidden_size)
-        q = q[:,self.sp_rank * self.sp_hidden_size:(self.sp_rank + 1) * self.sp_hidden_size]
+        q = q[
+            :,
+            self.sp_rank
+            * self.sp_hidden_size : (self.sp_rank + 1)
+            * self.sp_hidden_size,
+        ]
         attn_output = self.attn(q, k, v, input_metadata)
         output, _ = self.o_proj(attn_output)
         if input_metadata.sp_size > 1:

--- a/test/srt/test_seq_parallel_attn_kernel.py
+++ b/test/srt/test_seq_parallel_attn_kernel.py
@@ -1,0 +1,209 @@
+import pytest
+import torch
+from flashinfer import (
+    BatchDecodeWithPagedKVCacheWrapper,
+    BatchPrefillWithRaggedKVCacheWrapper,
+    BatchPrefillWithPagedKVCacheWrapper,
+)
+from flashinfer.cascade import merge_state
+from flashinfer.decode import _grouped_size_compiled_for_decode_kernels
+
+from sglang.srt.layers.extend_attention import extend_attention_fwd, redundant_attention
+from sglang.srt.layers.token_attention import token_attention_fwd
+
+flashinfer_prefill_wrapper_ragged = None
+flashinfer_prefill_wrapper_paged = None
+flashinfer_decode_wrapper = None
+
+
+@pytest.mark.parametrize("batch_size", [12, 37, 67])
+@pytest.mark.parametrize("kv_len", [54, 97])
+@pytest.mark.parametrize("qo_len", [37, 17])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [32, 4])
+@pytest.mark.parametrize("head_dim", [128])
+def test_seq_parallel_prefill(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+):
+    init_flashinfer(num_qo_heads, num_kv_heads)
+
+    q = torch.randn(batch_size, qo_len, num_qo_heads, head_dim).to(0).half()
+    k = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
+    v = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
+
+    def seq_parallel_worker_0_impl():
+        num_partitions = 2
+        num_iters = num_partitions
+        qo_len_per_iter = qo_len // num_iters
+        kv_len_per_partition = kv_len // num_partitions
+
+        def iter0(i = 0): # SP worker 0 iter 0
+            q0 = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
+            k0 = k[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
+            v0 = v[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
+
+            qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
+            kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
+            flashinfer_prefill_wrapper_ragged.end_forward()
+            flashinfer_prefill_wrapper_ragged.begin_forward(
+                qo_indptr,
+                kv_indptr,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+            )
+            o00 = flashinfer_prefill_wrapper_ragged.forward(
+                q0.contiguous().view(-1, num_qo_heads, head_dim),
+                k0.contiguous().view(-1, num_kv_heads, head_dim),
+                v0.contiguous().view(-1, num_kv_heads, head_dim),
+            )
+            flashinfer_prefill_wrapper_ragged.end_forward()
+            return o00
+        o00 = iter0()
+
+        def iter1(i = 1): # SP worker 0 iter 1
+            q1 = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
+            k1 = k[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
+            v1 = v[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
+
+            qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
+            kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
+
+            # TODO: we don't really need to re-setup ragged attention
+            flashinfer_prefill_wrapper_ragged.end_forward()
+            flashinfer_prefill_wrapper_ragged.begin_forward(
+                qo_indptr,
+                kv_indptr,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+            )
+            o11, s11 = flashinfer_prefill_wrapper_ragged.forward_return_lse(
+                q1.contiguous().view(-1, num_qo_heads, head_dim),
+                k1.contiguous().view(-1, num_kv_heads, head_dim),
+                v1.contiguous().view(-1, num_kv_heads, head_dim),
+            )
+            flashinfer_prefill_wrapper_ragged.end_forward()
+
+            k0 = k[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
+            v0 = v[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
+            kv_data0 = torch.zeros(batch_size * kv_len_per_partition, 2, num_kv_heads, head_dim).to(0).half()
+            kv_data0[:, 0] = k0.contiguous().view(-1, num_kv_heads, head_dim)
+            kv_data0[:, 1] = v0.contiguous().view(-1, num_kv_heads, head_dim)
+
+            kv_indices = torch.arange(0, batch_size * kv_len_per_partition).to(0).int()
+            kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
+
+            flashinfer_prefill_wrapper_paged.end_forward()
+            flashinfer_prefill_wrapper_paged.begin_forward(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                1,
+            )
+            o10, s10 = flashinfer_prefill_wrapper_paged.forward_return_lse(
+                q1.contiguous().view(-1, num_qo_heads, head_dim), kv_data0,
+                causal=False,
+            )
+            flashinfer_prefill_wrapper_paged.end_forward()
+
+            o1, _ = merge_state(o10, s10, o11, s11)
+            return o1
+
+        o1 = iter1()
+        o = torch.cat([
+                o00.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
+                o1.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
+            ], dim=1)
+        return o.view(-1, num_qo_heads, head_dim)
+
+    def reference_impl_ragged():
+        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len
+        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
+
+        flashinfer_prefill_wrapper_ragged.end_forward()
+        flashinfer_prefill_wrapper_ragged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+        )
+        o = flashinfer_prefill_wrapper_ragged.forward(
+            q.contiguous().view(-1, num_qo_heads, head_dim),
+            k.contiguous().view(-1, num_kv_heads, head_dim),
+            v.contiguous().view(-1, num_kv_heads, head_dim),
+        )
+        flashinfer_prefill_wrapper_ragged.end_forward()
+        return o
+
+    def reference_impl_paged():
+        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len
+        total_tokens = kv_len * batch_size
+
+        kv_data = torch.zeros(total_tokens, 2, num_kv_heads, head_dim).to(0).half()
+        kv_data[:, 0] = k.contiguous().view(-1, num_kv_heads, head_dim)
+        kv_data[:, 1] = v.contiguous().view(-1, num_kv_heads, head_dim)
+        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
+        kv_indices = torch.arange(0, total_tokens).to(0).int()
+        kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
+
+        flashinfer_prefill_wrapper_paged.end_forward()
+        flashinfer_prefill_wrapper_paged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            1,
+        )
+        o = flashinfer_prefill_wrapper_paged.forward(
+            q.contiguous().view(-1, num_qo_heads, head_dim), kv_data
+        )
+        flashinfer_prefill_wrapper_paged.end_forward()
+        return o
+
+    o_sp = seq_parallel_worker_0_impl()
+    o_truth = reference_impl_paged()
+
+    print("Mean: ", torch.mean(torch.abs(o_sp - o_truth)))
+    print("Max: ", torch.max(torch.abs(o_sp - o_truth)))
+    assert torch.allclose(o_sp, o_truth, rtol=1e-2, atol=1e-3)
+
+
+def init_flashinfer(num_attention_heads, num_kv_heads):
+    if not _grouped_size_compiled_for_decode_kernels(num_attention_heads, num_kv_heads):
+        use_tensor_cores = True
+    else:
+        use_tensor_cores = False
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
+
+    global flashinfer_prefill_wrapper_ragged, flashinfer_prefill_wrapper_paged, flashinfer_decode_wrapper
+
+    flashinfer_prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
+        workspace_buffer, "NHD"
+    )
+    flashinfer_prefill_wrapper_paged = BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD"
+    )
+    flashinfer_decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD", use_tensor_cores=use_tensor_cores
+    )
+
+
+if __name__ == "__main__":
+    test_seq_parallel_prefill(12, 128, 128, 8, 8, 128)
+    test_seq_parallel_prefill(12, 4096, 4096, 8, 8, 128)
+    test_seq_parallel_prefill(12, 1024, 1024, 32, 32, 128)

--- a/test/srt/test_seq_parallel_attn_kernel.py
+++ b/test/srt/test_seq_parallel_attn_kernel.py
@@ -16,6 +16,150 @@ flashinfer_prefill_wrapper_paged = None
 flashinfer_decode_wrapper = None
 
 
+def get_next_partition_id(curr_partition_id, num_partitions):
+    assert curr_partition_id < num_partitions
+    return (curr_partition_id - 1) % num_partitions
+
+
+def get_sp_prev_local_rank(rank, num_partitions):
+    return (rank - 1) % num_partitions
+
+
+def get_sp_next_local_rank(rank, num_partitions):
+    return (rank + 1) % num_partitions
+
+
+def append_merge_partition(partition_list, o, s):
+    if len(partition_list) == 0:
+        partition_list.append((o, s))
+    else:
+        o_prev, s_prev = partition_list[-1]
+        o, s = merge_state(o_prev, s_prev, o, s)
+        partition_list[-1] = (o, s)
+
+
+def seq_parallel_attn(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    q,
+    k,
+    v,
+    rank: int,
+    sp_size: int,
+):
+    """Simulate a sequence parallel attention kernel. It takes full Q, K, and V
+    with simulated communication. TODO: replace with actual communication.
+    """
+    num_partitions = sp_size
+    num_iters = sp_size
+    # NOTE: we assume sequence length is divisible by num_partitions
+    qo_len_per_iter = qo_len // num_iters
+    kv_len_per_partition = kv_len // num_partitions
+
+    qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
+    kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
+    flashinfer_prefill_wrapper_ragged.end_forward()
+    flashinfer_prefill_wrapper_ragged.begin_forward(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+    )
+
+    kv_indices = torch.arange(0, batch_size * kv_len_per_partition).to(0).int()
+    kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
+    flashinfer_prefill_wrapper_paged.end_forward()
+    flashinfer_prefill_wrapper_paged.begin_forward(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        1,
+    )
+
+    local_k, local_v = (
+        k[:, rank * kv_len_per_partition : (rank + 1) * kv_len_per_partition]
+        .contiguous()
+        .view(-1, num_kv_heads, head_dim),
+        v[:, rank * kv_len_per_partition : (rank + 1) * kv_len_per_partition]
+        .contiguous()
+        .view(-1, num_kv_heads, head_dim),
+    )
+    k_partition, v_partition = local_k, local_v
+
+    owned_pids = [rank]
+    owned_partitions = [None for _ in range(num_partitions)]
+    owned_partitions[rank] = (local_k, local_v)
+    o_partitions = [[] for _ in range(num_partitions)]
+
+    to_rank = rank  # which SP worker to send my sequence KV partition to.
+    from_rank = rank  # which SP worker to receive the sequence KV partition from.
+
+    pid = rank  # start from the worker's own partition
+    for _ in range(num_iters):
+        # TODO: send-recv communication here
+        to_rank = get_sp_next_local_rank(to_rank, num_partitions)
+        # send_to(to_rank, k, v)
+        q_partition = q[:, pid * qo_len_per_iter : (pid + 1) * qo_len_per_iter]
+        k_partition, v_partition = owned_partitions[pid]
+        # Ragged attention computation for self attention within the partition
+        o, s = flashinfer_prefill_wrapper_ragged.forward_return_lse(
+            q_partition.contiguous().view(-1, num_qo_heads, head_dim),
+            k_partition.contiguous().view(-1, num_kv_heads, head_dim),
+            v_partition.contiguous().view(-1, num_kv_heads, head_dim),
+        )
+        append_merge_partition(o_partitions[pid], o, s)
+        # Paged attention computation for cross partition attention
+        # NOTE: below schedule is for load balancing
+        for existing_pid in owned_pids[:-1]:
+            if existing_pid == pid:
+                continue
+            i, j = (existing_pid, pid) if existing_pid > pid else (pid, existing_pid)
+            q_data = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
+            kv_data = torch.stack(owned_partitions[j], dim=1)
+            o, s = flashinfer_prefill_wrapper_paged.forward_return_lse(
+                q_data.contiguous().view(-1, num_qo_heads, head_dim),
+                kv_data,
+                causal=False,
+            )
+            append_merge_partition(o_partitions[i], o, s)
+
+        # TODO: send-recv communication here
+        from_rank = get_sp_prev_local_rank(from_rank, num_partitions)
+        # recv_from(from_rank, k, v)
+        pid = from_rank
+        kv_recved = (
+            k[:, pid * kv_len_per_partition : (pid + 1) * kv_len_per_partition]
+            .contiguous()
+            .view(-1, num_kv_heads, head_dim),
+            v[:, pid * kv_len_per_partition : (pid + 1) * kv_len_per_partition]
+            .contiguous()
+            .view(-1, num_kv_heads, head_dim),
+        )
+        owned_pids.append(pid)
+        owned_partitions[pid] = kv_recved
+
+    # Reshape all o tensors so that we can concatenate along the sequence dimension
+    # we must have len(partition_list) == 1 here
+    os = [
+        o.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim)
+        for partition_list in o_partitions
+        for o, _ in partition_list
+    ]
+    o = torch.cat(os, dim=1).view(
+        -1, num_qo_heads, head_dim
+    )  # restore the original shape
+    return o
+
+
 @pytest.mark.parametrize("batch_size", [12, 37, 67])
 @pytest.mark.parametrize("kv_len", [54, 97])
 @pytest.mark.parametrize("qo_len", [37, 17])
@@ -29,193 +173,14 @@ def test_seq_parallel_prefill(
     num_kv_heads,
     num_qo_heads,
     head_dim,
+    rank: int = 0,
+    sp_size: int = 2,
 ):
     init_flashinfer(num_qo_heads, num_kv_heads)
 
     q = torch.randn(batch_size, qo_len, num_qo_heads, head_dim).to(0).half()
     k = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
     v = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
-
-    def seq_parallel_worker_0_impl():
-        num_partitions = 2
-        num_iters = num_partitions
-        qo_len_per_iter = qo_len // num_iters
-        kv_len_per_partition = kv_len // num_partitions
-
-        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
-        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
-        flashinfer_prefill_wrapper_ragged.end_forward()
-        flashinfer_prefill_wrapper_ragged.begin_forward(
-            qo_indptr,
-            kv_indptr,
-            num_qo_heads,
-            num_kv_heads,
-            head_dim,
-        )
-
-        kv_indices = torch.arange(0, batch_size * kv_len_per_partition).to(0).int()
-        kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
-
-        flashinfer_prefill_wrapper_paged.end_forward()
-        flashinfer_prefill_wrapper_paged.begin_forward(
-            qo_indptr,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            num_qo_heads,
-            num_kv_heads,
-            head_dim,
-            1,
-        )
-
-        def iter0(i=0):  # SP worker 0 iter 0
-            q0 = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
-            k0 = k[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
-            v0 = v[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
-
-            o00 = flashinfer_prefill_wrapper_ragged.forward(
-                q0.contiguous().view(-1, num_qo_heads, head_dim),
-                k0.contiguous().view(-1, num_kv_heads, head_dim),
-                v0.contiguous().view(-1, num_kv_heads, head_dim),
-            )
-            return o00
-
-        o00 = iter0()
-
-        def iter1(i=1):  # SP worker 0 iter 1
-            q1 = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
-            k1 = k[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
-            v1 = v[:, i * kv_len_per_partition : (i + 1) * kv_len_per_partition]
-
-            o11, s11 = flashinfer_prefill_wrapper_ragged.forward_return_lse(
-                q1.contiguous().view(-1, num_qo_heads, head_dim),
-                k1.contiguous().view(-1, num_kv_heads, head_dim),
-                v1.contiguous().view(-1, num_kv_heads, head_dim),
-            )
-
-            k0 = k[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
-            v0 = v[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
-            kv_data0 = (
-                torch.zeros(
-                    batch_size * kv_len_per_partition, 2, num_kv_heads, head_dim
-                )
-                .to(0)
-                .half()
-            )
-            kv_data0[:, 0] = k0.contiguous().view(-1, num_kv_heads, head_dim)
-            kv_data0[:, 1] = v0.contiguous().view(-1, num_kv_heads, head_dim)
-
-            o10, s10 = flashinfer_prefill_wrapper_paged.forward_return_lse(
-                q1.contiguous().view(-1, num_qo_heads, head_dim),
-                kv_data0,
-                causal=False,
-            )
-            flashinfer_prefill_wrapper_paged.end_forward()
-
-            o1, _ = merge_state(o10, s10, o11, s11)
-            return o1
-
-        o1 = iter1()
-
-        o = torch.cat(
-            [
-                o00.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
-                o1.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
-            ],
-            dim=1,
-        )
-        return o.view(-1, num_qo_heads, head_dim)
-
-    def seq_parallel_worker_1_impl():
-        num_partitions = 2
-        num_iters = num_partitions
-        qo_len_per_iter = qo_len // num_iters
-        kv_len_per_partition = kv_len // num_partitions
-
-        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
-        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
-        flashinfer_prefill_wrapper_ragged.end_forward()
-        flashinfer_prefill_wrapper_ragged.begin_forward(
-            qo_indptr,
-            kv_indptr,
-            num_qo_heads,
-            num_kv_heads,
-            head_dim,
-        )
-
-        kv_indices = torch.arange(0, batch_size * kv_len_per_partition).to(0).int()
-        kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
-        flashinfer_prefill_wrapper_paged.end_forward()
-        flashinfer_prefill_wrapper_paged.begin_forward(
-            qo_indptr,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            num_qo_heads,
-            num_kv_heads,
-            head_dim,
-            1,
-        )
-
-        def iter0(i=0):  # SP worker 1 iter 0
-            q1 = q[:, (i + 1) * qo_len_per_iter : (i + 2) * qo_len_per_iter]
-            k1 = k[:, (i + 1) * kv_len_per_partition : (i + 2) * kv_len_per_partition]
-            v1 = v[:, (i + 1) * kv_len_per_partition : (i + 2) * kv_len_per_partition]
-
-            o11, s11 = flashinfer_prefill_wrapper_ragged.forward_return_lse(
-                q1.contiguous().view(-1, num_qo_heads, head_dim),
-                k1.contiguous().view(-1, num_kv_heads, head_dim),
-                v1.contiguous().view(-1, num_kv_heads, head_dim),
-            )
-            return o11, s11
-
-        o11, s11 = iter0()
-
-        def iter1(i=1):  # SP worker 1 iter 1
-            q0 = q[:, (i - 1) * qo_len_per_iter : i * qo_len_per_iter]
-            k0 = k[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
-            v0 = v[:, (i - 1) * kv_len_per_partition : i * kv_len_per_partition]
-
-            qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
-            kv_indptr = (
-                torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
-            )
-
-            o00 = flashinfer_prefill_wrapper_ragged.forward(
-                q0.contiguous().view(-1, num_qo_heads, head_dim),
-                k0.contiguous().view(-1, num_kv_heads, head_dim),
-                v0.contiguous().view(-1, num_kv_heads, head_dim),
-            )
-
-            q1 = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
-            kv_data0 = (
-                torch.zeros(
-                    batch_size * kv_len_per_partition, 2, num_kv_heads, head_dim
-                )
-                .to(0)
-                .half()
-            )
-            kv_data0[:, 0] = k0.contiguous().view(-1, num_kv_heads, head_dim)
-            kv_data0[:, 1] = v0.contiguous().view(-1, num_kv_heads, head_dim)
-
-            o10, s10 = flashinfer_prefill_wrapper_paged.forward_return_lse(
-                q1.contiguous().view(-1, num_qo_heads, head_dim),
-                kv_data0,
-                causal=False,
-            )
-
-            return o00, o10, s10
-
-        o00, o10, s10 = iter1()
-        o1, _ = merge_state(o10, s10, o11, s11)
-        o = torch.cat(
-            [
-                o00.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
-                o1.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim),
-            ],
-            dim=1,
-        )
-        return o.view(-1, num_qo_heads, head_dim)
 
     def reference_impl_ragged():
         qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len
@@ -265,7 +230,19 @@ def test_seq_parallel_prefill(
         flashinfer_prefill_wrapper_paged.end_forward()
         return o
 
-    o_sp = seq_parallel_worker_1_impl()
+    o_sp = seq_parallel_attn(
+        batch_size,
+        kv_len,
+        qo_len,
+        num_kv_heads,
+        num_qo_heads,
+        head_dim,
+        q,
+        k,
+        v,
+        rank=1,
+        sp_size=4,
+    )
     o_truth = reference_impl_paged()
 
     print("Mean: ", torch.mean(torch.abs(o_sp - o_truth)))
@@ -297,9 +274,6 @@ def init_flashinfer(num_attention_heads, num_kv_heads):
 
 
 if __name__ == "__main__":
-    test_seq_parallel_prefill(12, 128, 128, 8, 8, 128)
-    test_seq_parallel_prefill(12, 4096, 4096, 8, 8, 128)
-    test_seq_parallel_prefill(12, 1024, 1024, 32, 32, 128)
-    # test_seq_parallel_prefill(12, 54, 37, 8, 8, 128)
-    # test_seq_parallel_prefill(37, 1111, 456, 32, 32, 128)
-    # test_seq_parallel_decode_(12, 54, 4, 32, 128)
+    test_seq_parallel_prefill(12, 128, 128, 8, 8, 128, rank=3, sp_size=4)
+    test_seq_parallel_prefill(12, 4096, 4096, 8, 8, 128, rank=4, sp_size=8)
+    test_seq_parallel_prefill(12, 1024, 1024, 32, 32, 128, rank=1, sp_size=2)

--- a/test/srt/test_seq_parallel_attn_kernel.py
+++ b/test/srt/test_seq_parallel_attn_kernel.py
@@ -119,7 +119,7 @@ def seq_parallel_attn(
         append_merge_partition(o_partitions[pid], o, s)
         # Paged attention computation for cross partition attention
         # NOTE: below schedule is for load balancing
-        for existing_pid in owned_pids[:-1]:
+        for existing_pid in owned_pids:
             if existing_pid == pid:
                 continue
             i, j = (existing_pid, pid) if existing_pid > pid else (pid, existing_pid)

--- a/test/srt/test_seq_parallel_attn_kernel_simple.py
+++ b/test/srt/test_seq_parallel_attn_kernel_simple.py
@@ -1,0 +1,279 @@
+import pytest
+import torch
+from flashinfer import (
+    BatchDecodeWithPagedKVCacheWrapper,
+    BatchPrefillWithPagedKVCacheWrapper,
+    BatchPrefillWithRaggedKVCacheWrapper,
+)
+from flashinfer.cascade import merge_state
+from flashinfer.decode import _grouped_size_compiled_for_decode_kernels
+
+from sglang.srt.layers.extend_attention import extend_attention_fwd, redundant_attention
+from sglang.srt.layers.token_attention import token_attention_fwd
+
+flashinfer_prefill_wrapper_ragged = None
+flashinfer_prefill_wrapper_paged = None
+flashinfer_decode_wrapper = None
+
+
+def get_next_partition_id(curr_partition_id, num_partitions):
+    assert curr_partition_id < num_partitions
+    return (curr_partition_id - 1) % num_partitions
+
+
+def get_sp_prev_local_rank(rank, num_partitions):
+    return (rank - 1) % num_partitions
+
+
+def get_sp_next_local_rank(rank, num_partitions):
+    return (rank + 1) % num_partitions
+
+
+def append_merge_partition(partition_list, o, s):
+    if len(partition_list) == 0:
+        partition_list.append((o, s))
+    else:
+        o_prev, s_prev = partition_list[-1]
+        o, s = merge_state(o_prev, s_prev, o, s)
+        partition_list[-1] = (o, s)
+
+
+def seq_parallel_attn(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    q,
+    k,
+    v,
+    rank: int,
+    sp_size: int,
+):
+    """Simulate a sequence parallel attention kernel. It takes full Q, K, and V
+    with simulated communication. TODO: replace with actual communication.
+    """
+    num_partitions = sp_size
+    num_iters = sp_size
+    # NOTE: we assume sequence length is divisible by num_partitions
+    qo_len_per_iter = qo_len // num_iters
+    kv_len_per_partition = kv_len // num_partitions
+
+    qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len_per_iter
+    kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len_per_partition
+    flashinfer_prefill_wrapper_ragged.end_forward()
+    flashinfer_prefill_wrapper_ragged.begin_forward(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+    )
+
+    kv_indices = torch.arange(0, batch_size * kv_len_per_partition).to(0).int()
+    kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
+    flashinfer_prefill_wrapper_paged.end_forward()
+    flashinfer_prefill_wrapper_paged.begin_forward(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        1,
+    )
+
+    local_k, local_v = (
+        k[:, rank * kv_len_per_partition : (rank + 1) * kv_len_per_partition]
+        .contiguous()
+        .view(-1, num_kv_heads, head_dim),
+        v[:, rank * kv_len_per_partition : (rank + 1) * kv_len_per_partition]
+        .contiguous()
+        .view(-1, num_kv_heads, head_dim),
+    )
+    k_partition, v_partition = local_k, local_v
+
+    owned_pids = [rank]
+    owned_partitions = [None for _ in range(num_partitions)]
+    owned_partitions[rank] = (local_k, local_v)
+    o_partitions = [[] for _ in range(num_partitions)]
+
+    to_rank = rank  # which SP worker to send my sequence KV partition to.
+    from_rank = rank  # which SP worker to receive the sequence KV partition from.
+
+    pid = rank  # start from the worker's own partition
+    for _ in range(num_iters):
+        # TODO: send-recv communication here
+        to_rank = get_sp_next_local_rank(to_rank, num_partitions)
+        # send_to(to_rank, k, v)
+        q_partition = q[:, pid * qo_len_per_iter : (pid + 1) * qo_len_per_iter]
+        k_partition, v_partition = owned_partitions[pid]
+        # Ragged attention computation for self attention within the partition
+        o, s = flashinfer_prefill_wrapper_ragged.forward_return_lse(
+            q_partition.contiguous().view(-1, num_qo_heads, head_dim),
+            k_partition.contiguous().view(-1, num_kv_heads, head_dim),
+            v_partition.contiguous().view(-1, num_kv_heads, head_dim),
+        )
+        append_merge_partition(o_partitions[pid], o, s)
+        # Paged attention computation for cross partition attention
+        # NOTE: below schedule is for load balancing
+        for existing_pid in owned_pids:
+            if existing_pid == pid:
+                continue
+            i, j = (existing_pid, pid) if existing_pid > pid else (pid, existing_pid)
+            q_data = q[:, i * qo_len_per_iter : (i + 1) * qo_len_per_iter]
+            kv_data = torch.stack(owned_partitions[j], dim=1)
+            o, s = flashinfer_prefill_wrapper_paged.forward_return_lse(
+                q_data.contiguous().view(-1, num_qo_heads, head_dim),
+                kv_data,
+                causal=False,
+            )
+            append_merge_partition(o_partitions[i], o, s)
+
+        # TODO: send-recv communication here
+        from_rank = get_sp_prev_local_rank(from_rank, num_partitions)
+        # recv_from(from_rank, k, v)
+        pid = from_rank
+        kv_recved = (
+            k[:, pid * kv_len_per_partition : (pid + 1) * kv_len_per_partition]
+            .contiguous()
+            .view(-1, num_kv_heads, head_dim),
+            v[:, pid * kv_len_per_partition : (pid + 1) * kv_len_per_partition]
+            .contiguous()
+            .view(-1, num_kv_heads, head_dim),
+        )
+        owned_pids.append(pid)
+        owned_partitions[pid] = kv_recved
+
+    # Reshape all o tensors so that we can concatenate along the sequence dimension
+    # we must have len(partition_list) == 1 here
+    os = [
+        o.view(batch_size, qo_len_per_iter, num_qo_heads, head_dim)
+        for partition_list in o_partitions
+        for o, _ in partition_list
+    ]
+    o = torch.cat(os, dim=1).view(
+        -1, num_qo_heads, head_dim
+    )  # restore the original shape
+    return o
+
+
+@pytest.mark.parametrize("batch_size", [12, 37, 67])
+@pytest.mark.parametrize("kv_len", [54, 97])
+@pytest.mark.parametrize("qo_len", [37, 17])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [32, 4])
+@pytest.mark.parametrize("head_dim", [128])
+def test_seq_parallel_prefill(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    rank: int = 0,
+    sp_size: int = 2,
+):
+    init_flashinfer(num_qo_heads, num_kv_heads)
+
+    q = torch.randn(batch_size, qo_len, num_qo_heads, head_dim).to(0).half()
+    k = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
+    v = torch.randn(batch_size, kv_len, num_kv_heads, head_dim).to(0).half()
+
+    def reference_impl_ragged():
+        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len
+        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
+
+        flashinfer_prefill_wrapper_ragged.end_forward()
+        flashinfer_prefill_wrapper_ragged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+        )
+        o = flashinfer_prefill_wrapper_ragged.forward(
+            q.contiguous().view(-1, num_qo_heads, head_dim),
+            k.contiguous().view(-1, num_kv_heads, head_dim),
+            v.contiguous().view(-1, num_kv_heads, head_dim),
+        )
+        flashinfer_prefill_wrapper_ragged.end_forward()
+        return o
+
+    def reference_impl_paged():
+        qo_indptr = torch.arange(0, batch_size + 1).to(0).int() * qo_len
+        total_tokens = kv_len * batch_size
+
+        kv_data = torch.zeros(total_tokens, 2, num_kv_heads, head_dim).to(0).half()
+        kv_data[:, 0] = k.contiguous().view(-1, num_kv_heads, head_dim)
+        kv_data[:, 1] = v.contiguous().view(-1, num_kv_heads, head_dim)
+        kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
+        kv_indices = torch.arange(0, total_tokens).to(0).int()
+        kv_last_page_len = torch.full((batch_size,), 1, dtype=torch.int32).to(0)
+
+        flashinfer_prefill_wrapper_paged.end_forward()
+        flashinfer_prefill_wrapper_paged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            1,
+        )
+        o = flashinfer_prefill_wrapper_paged.forward(
+            q.contiguous().view(-1, num_qo_heads, head_dim), kv_data
+        )
+        flashinfer_prefill_wrapper_paged.end_forward()
+        return o
+
+    o_sp = seq_parallel_attn(
+        batch_size,
+        kv_len,
+        qo_len,
+        num_kv_heads,
+        num_qo_heads,
+        head_dim,
+        q,
+        k,
+        v,
+        rank=1,
+        sp_size=4,
+    )
+    o_truth = reference_impl_paged()
+
+    print("Mean: ", torch.mean(torch.abs(o_sp - o_truth)))
+    print("Max: ", torch.max(torch.abs(o_sp - o_truth)))
+    assert torch.allclose(o_sp, o_truth, rtol=1e-2, atol=1e-3)
+
+
+def init_flashinfer(num_attention_heads, num_kv_heads):
+    if not _grouped_size_compiled_for_decode_kernels(num_attention_heads, num_kv_heads):
+        use_tensor_cores = True
+    else:
+        use_tensor_cores = False
+
+    workspace_buffer = torch.empty(
+        3, 128 * 1024 * 1024, dtype=torch.int8, device="cuda"
+    )
+
+    global flashinfer_prefill_wrapper_ragged, flashinfer_prefill_wrapper_paged, flashinfer_decode_wrapper
+
+    flashinfer_prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
+        workspace_buffer[0], "NHD"
+    )
+    flashinfer_prefill_wrapper_paged = BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer[1], "NHD"
+    )
+    flashinfer_decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer[2], "NHD", use_tensor_cores=use_tensor_cores
+    )
+
+
+if __name__ == "__main__":
+    test_seq_parallel_prefill(12, 128, 128, 8, 8, 128, rank=3, sp_size=4)
+    test_seq_parallel_prefill(12, 4096, 4096, 8, 8, 128, rank=4, sp_size=8)
+    test_seq_parallel_prefill(12, 1024, 1024, 32, 32, 128, rank=1, sp_size=2)

--- a/test/srt/test_sp_comm_group.py
+++ b/test/srt/test_sp_comm_group.py
@@ -1,0 +1,70 @@
+import multiprocessing
+import random
+
+import torch
+from vllm.distributed import init_distributed_environment
+
+from sglang.srt.layers.parallel_utils import get_sp_group, initialize_model_parallel
+
+NUM_TOKENS = 3
+NUM_KV_HEADS = 2
+HEAD_DIM = 4
+
+
+def gen_kv(rank: int = 0, sp_size: int = 1):
+    torch.manual_seed(42)
+    random.seed(42)
+    k = torch.randn(NUM_TOKENS, NUM_KV_HEADS, HEAD_DIM).cuda().half()
+    v = torch.randn(NUM_TOKENS, NUM_KV_HEADS, HEAD_DIM).cuda().half()
+
+    return k, v
+
+
+def sp_worker(rank: int = 0, sp_size: int = 1, tp_size: int = 1):
+    torch.manual_seed(42)
+    random.seed(42)
+
+    nccl_init_method = f"tcp://127.0.0.1:28888"
+    init_distributed_environment(
+        backend="nccl",
+        world_size=tp_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=nccl_init_method,
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=tp_size, sequence_parallel_size=sp_size
+    )
+    torch.cuda.set_device(rank)
+    print("SP worker", rank, "initialized on", torch.cuda.current_device())
+
+    k, v = gen_kv(rank, sp_size)
+
+    ks = get_sp_group().all_gather(k.view(1, *k.shape), dim=0)
+    vs = get_sp_group().all_gather(v.view(1, *v.shape), dim=0)
+
+    print("SP worker", rank, "all-gathered ks", ks)
+    print("SP worker", rank, "all-gathered vs", vs)
+
+
+def main():
+    sp_size = 2
+    tp_size = 2
+
+    multiprocessing.set_start_method("spawn", force=True)
+    sp_procs = []
+    for rank in range(1, sp_size):
+        sp_proc = multiprocessing.Process(
+            target=sp_worker, args=(rank, sp_size, tp_size)
+        )
+        sp_proc.start()
+        sp_procs.append(sp_proc)
+
+    sp_worker(0, sp_size, tp_size)
+
+    for sp_proc in sp_procs:
+        sp_proc.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR mainly implemented `RadixAttention.seq_parallel_extend_forward_flashinfer()` method. We adopted the parallelization strategy discussed before and overlapped communication and computation in each iteration within the ring attention algorithm. Specifically, each SP worker has: 

* q tensor: [batch_size, seq_len, q_head_num // SP_SIZE, head_dim] # partitioned along the `q_head_num` dimension. Assuming that `q_head_num` is divisible by `SP_SIZE`.
* k tensor: [batch_size, seq_len // SP_SIZE, k_head_num, head_dim] # Here `seq_len // SP_SIZE` should be adjusted correspondingly when `seq_len` cannot be divisible by `SP_SIZE`.
* v tensor: [batch_size, seq_len // SP_SIZE, v_head_num, head_dim] # Same as k tensor

*NOTE*: for now the kernel is only tested when `seq_len` can be divided by `SP_SIZE`. Will update the code later.

To balance the workload of all workers, we schedule the computation tasks in the following way:
At iteration `i` (starting from 0), each SP worker will compute the self-attention for its currently active shard (calling ragged attention kernel), and `i` number of cross-shard attention (calling paged attention kernel). SP workers have a perfectly balanced workload in each iteration, although the workload per iteration increases step by step. We will need to further investigate the performance impact of this design.