### PR TITLE
Create SP communication groups

### DIFF
--- a/python/sglang/srt/layers/parallel_utils/__init__.py
+++ b/python/sglang/srt/layers/parallel_utils/__init__.py
@@ -1,0 +1,1 @@
+from .parallel_state import *

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -79,9 +79,13 @@ def get_sequence_parallel_rank():
     return get_sp_group().rank_in_group
 
 
-def get_actual_tensor_model_parallel_world_size():
+# NOTE: For sequence parallelism, we partition Q tensors along the head dimension.
+# But K/V tensors are partitioned along the head dimension in TP and partitioned
+# along the sequence dimensions in SP. Therefore, their TP size and rank is adjusted
+# accordingly as below.
+def get_kv_tensor_model_parallel_world_size():
     return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
 
 
-def get_actual_tensor_model_parallel_rank():
+def get_kv_tensor_model_parallel_rank():
     return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -1,0 +1,74 @@
+from typing import List, Optional
+
+import torch
+from vllm.distributed import initialize_model_parallel as vllm_initialize_model_parallel
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    get_world_group,
+    init_model_parallel_group,
+)
+
+_SP: Optional[GroupCoordinator] = None
+
+
+def get_sp_group():
+    assert _SP is not None, "sequence parallel group is not initialized"
+    return _SP
+
+
+def init_sequence_parallel_group(
+    group_ranks: List[List[int]], local_rank: int, backend: str
+) -> GroupCoordinator:
+    return GroupCoordinator(
+        group_ranks=group_ranks,
+        local_rank=local_rank,
+        torch_distributed_backend=backend,
+        use_pynccl=True,
+    )
+
+
+def initialize_model_parallel(
+    tensor_model_parallel_size: int = 1,
+    pipeline_model_parallel_size: int = 1,
+    sequence_parallel_size: int = 1,
+    backend: Optional[str] = None,
+) -> None:
+    assert torch.distributed.is_initialized()
+    world_size: int = torch.distributed.get_world_size()
+    backend = backend or torch.distributed.get_backend(get_world_group().device_group)
+
+    num_sequence_parallel_groups: int = world_size // sequence_parallel_size
+    global _SP
+    assert _SP is None, "sequence parallel group is already initialized"
+    group_ranks = []
+    for i in range(num_sequence_parallel_groups):
+        ranks = list(
+            range(i * sequence_parallel_size, (i + 1) * sequence_parallel_size)
+        )
+        group_ranks.append(ranks)
+    _SP = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend)
+    vllm_initialize_model_parallel(
+        tensor_model_parallel_size, pipeline_model_parallel_size, backend
+    )
+
+
+def sequence_parallel_is_initialized():
+    return _SP is not None
+
+
+def get_sequence_parallel_world_size():
+    return get_sp_group().world_size
+
+
+def get_sequence_parallel_rank():
+    return get_sp_group().rank_in_group
+
+
+def get_actual_tensor_model_parallel_world_size():
+    return get_tensor_model_parallel_world_size() // get_sequence_parallel_world_size()
+
+
+def get_actual_tensor_model_parallel_rank():
+    return get_tensor_model_parallel_rank() // get_sequence_parallel_world_size()

--- a/python/sglang/srt/layers/parallel_utils/parallel_state.py
+++ b/python/sglang/srt/layers/parallel_utils/parallel_state.py
@@ -35,6 +35,19 @@ def initialize_model_parallel(
     sequence_parallel_size: int = 1,
     backend: Optional[str] = None,
 ) -> None:
+    """
+    Initialize model parallel groups and sequence parallel groups.
+
+    For sequence parallelism, we partition SP groups within a TP group, and assign
+    gpus with adjacent ranks to the same SP group. For example, with TP size 8
+    and SP size 2, we have 1 TP group and 4 SP groups:
+    SP groups:
+        [g0, g1], [g2, g3], [g4, g5], [g6, g7]
+    Their actual TP rank:
+        [ 0,  0], [ 1,  1], [ 2,  2], [ 3,  3]
+    In this case, we also say that the actual TP size is 4 (8//2), and gpus in each
+    SP group have actual tp rank from 0 to 3.
+    """
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
     backend = backend or torch.distributed.get_backend(get_world_group().device_group)

--- a/python/sglang/srt/managers/controller/model_runner.py
+++ b/python/sglang/srt/managers/controller/model_runner.py
@@ -17,15 +17,12 @@ from flashinfer import (
 from flashinfer.decode import _grouped_size_compiled_for_decode_kernels
 from vllm.config import DeviceConfig, LoadConfig
 from vllm.config import ModelConfig as VllmModelConfig
-from vllm.distributed import (
-    get_tp_group,
-    init_distributed_environment,
-    initialize_model_parallel,
-)
+from vllm.distributed import get_tp_group, init_distributed_environment
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import ModelRegistry
 
 from sglang.global_config import global_config
+from sglang.srt.layers.parallel_utils import initialize_model_parallel
 from sglang.srt.managers.controller.infer_batch import Batch, ForwardMode, InputMetadata
 from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
 from sglang.srt.server_args import ServerArgs
@@ -83,7 +80,9 @@ class ModelRunner:
             local_rank=self.gpu_id,
             distributed_init_method=nccl_init_method,
         )
-        initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
+        initialize_model_parallel(
+            tensor_model_parallel_size=self.tp_size, sequence_parallel_size=self.sp_size
+        )
         self.tp_group = get_tp_group()
         total_gpu_memory = get_available_gpu_memory(
             self.gpu_id, distributed=self.tp_size > 1

--- a/test/srt/test_sp_comm_group.py
+++ b/test/srt/test_sp_comm_group.py
@@ -1,0 +1,70 @@
+import multiprocessing
+import random
+
+import torch
+from vllm.distributed import init_distributed_environment
+
+from sglang.srt.layers.parallel_utils import get_sp_group, initialize_model_parallel
+
+NUM_TOKENS = 3
+NUM_KV_HEADS = 2
+HEAD_DIM = 4
+
+
+def gen_kv(rank: int = 0, sp_size: int = 1):
+    torch.manual_seed(42)
+    random.seed(42)
+    k = torch.randn(NUM_TOKENS, NUM_KV_HEADS, HEAD_DIM).cuda().half()
+    v = torch.randn(NUM_TOKENS, NUM_KV_HEADS, HEAD_DIM).cuda().half()
+
+    return k, v
+
+
+def sp_worker(rank: int = 0, sp_size: int = 1, tp_size: int = 1):
+    torch.manual_seed(42)
+    random.seed(42)
+
+    nccl_init_method = f"tcp://127.0.0.1:28888"
+    init_distributed_environment(
+        backend="nccl",
+        world_size=tp_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=nccl_init_method,
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=tp_size, sequence_parallel_size=sp_size
+    )
+    torch.cuda.set_device(rank)
+    print("SP worker", rank, "initialized on", torch.cuda.current_device())
+
+    k, v = gen_kv(rank, sp_size)
+
+    ks = get_sp_group().all_gather(k.view(1, *k.shape), dim=0)
+    vs = get_sp_group().all_gather(v.view(1, *v.shape), dim=0)
+
+    print("SP worker", rank, "all-gathered ks", ks)
+    print("SP worker", rank, "all-gathered vs", vs)
+
+
+def main():
+    sp_size = 2
+    tp_size = 2
+
+    multiprocessing.set_start_method("spawn", force=True)
+    sp_procs = []
+    for rank in range(1, sp_size):
+        sp_proc = multiprocessing.Process(
+            target=sp_worker, args=(rank, sp_size, tp_size)
+        )
+        sp_proc.start()
+        sp_procs.append(sp_proc)
+
+    sp_worker(0, sp_size, tp_size)
+
+    for sp_proc in sp_procs:
+        sp_proc.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR creates communication groups for sequence parallel workers. For sequence parallelism, we partition SP groups within a TP group, and assign gpus with adjacent ranks to the same SP group. 

For example, with TP size 8 and SP size 2, we will have 1 TP group and 4 SP groups:
```text
SP groups:
    [g0, g1], [g2, g3], [g4, g5], [g6, g7]
Their actual TP rank:
    [ 0,  0], [ 1,  1], [ 2,  2], [ 3,  3]
```

In this case, we also say that the actual TP size is 4 (==8//2), and gpus in each SP group have actual tp rank from 0 to 3.